### PR TITLE
fix: rebuild context graph for v3

### DIFF
--- a/plugins/alive/scripts/generate-graph.py
+++ b/plugins/alive/scripts/generate-graph.py
@@ -1,19 +1,11 @@
 #!/usr/bin/env python3
-"""ALIVE Context Graph Generator v3
+"""ALIVE Context Graph Generator v4 — Force-Directed with Domain Clustering
 
-Reads _index.json and generates an interactive D3.js force-directed graph.
-Run after generate-index.py to create .alive/context-graph.html.
+Reads _index.json and generates an interactive D3.js force-directed graph
+with domain gravity wells, neighborhood highlighting, and semantic zoom.
 
-Features:
-- ALIVE branded (cream light mode default, forest green dark mode)
-- Custom fonts (Array, Khand, Inter)
-- Light/dark theme toggle
-- Expandable capsule nodes (click walnut to show/hide capsules)
-- Click-to-pin details panel
-- Edge labels on hover
-- Domain region labels in cluster mode
-- Search with / hotkey
-- People connectors toggle
+Design informed by Obsidian graph view research, Cambridge Intelligence
+layout patterns, and D3 force best practices.
 
 Usage: python3 .alive/scripts/generate-graph.py [world-root]
 """
@@ -23,6 +15,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from collections import defaultdict
+import math
 
 
 def main():
@@ -31,80 +24,142 @@ def main():
     json_file = os.path.join(world_root, '.alive', '_index.json')
     html_file = os.path.join(world_root, '.alive', 'context-graph.html')
 
-    try:
-        with open(json_file, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-    except (IOError, json.JSONDecodeError) as e:
-        print(f"Error reading {json_file}: {e}", file=sys.stderr)
-        sys.exit(1)
+    with open(json_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
 
     stats = data['stats']
     walnuts = data['walnuts']
+    people = data.get('people', [])
     today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
+    nodes, links, people_nodes, people_links = build_graph_data(
+        walnuts, people, today
+    )
+
+    nj = json.dumps(nodes, ensure_ascii=False)
+    lj = json.dumps(links, ensure_ascii=False)
+    pnj = json.dumps(people_nodes, ensure_ascii=False)
+    plj = json.dumps(people_links, ensure_ascii=False)
+
+    html = build_html(stats, nj, lj, pnj, plj)
+    with open(html_file, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+    print(f"Graph: {html_file}")
+    print(f"Nodes: {len(nodes)} + {len(people_nodes)} people | "
+          f"Edges: {len(links)} + {len(people_links)} people")
+
+
+def build_graph_data(walnuts, people, today):
+    """Build nodes and links for force-directed graph."""
     nodes = []
     node_ids = set()
+    link_set = set()
+    links = []
+
+    # Compute degree for each walnut (for sizing)
+    degree = defaultdict(int)
+    for w in walnuts:
+        for target in w.get('links', []):
+            degree[w['name']] += 1
+            degree[target] += 1
+        if w.get('parent'):
+            degree[w['name']] += 1
+            degree[w['parent']] += 1
 
     for w in walnuts:
         wid = w['name']
         domain = w.get('domain', 'unknown')
-        phase = w.get('phase', 'unknown')
-        updated = w.get('updated', '2026-01-01')[:10]
-        capsule_count = w.get('capsule_count', 0)
-        capsule_details = w.get('capsules', [])
+        updated = w.get('updated', '')[:10]
+        bundles = w.get('capsule_count', 0)
         sessions = w.get('squirrel_sessions', 0)
         archived = w.get('archived', False)
 
         try:
-            days_since = (datetime.strptime(today, '%Y-%m-%d') -
-                         datetime.strptime(updated, '%Y-%m-%d')).days
-        except (ValueError, TypeError, KeyError):
-            days_since = 30
+            days = (datetime.strptime(today, '%Y-%m-%d') -
+                    datetime.strptime(updated, '%Y-%m-%d')).days
+        except (ValueError, TypeError):
+            days = 60
 
-        if capsule_count >= 15: size = 20
-        elif capsule_count >= 5: size = 15
-        elif capsule_count >= 1: size = 11
-        elif days_since <= 2: size = 12
-        elif days_since <= 7: size = 9
-        elif days_since <= 14: size = 7
-        else: size = 5
+        # Size by degree + activity (wider range for visual hierarchy)
+        deg = degree.get(wid, 0)
+        size = 4 + math.sqrt(deg) * 4 + min(bundles, 15) * 1.2
+        if days <= 3:
+            size += 5
+        elif days <= 7:
+            size += 3
+        elif days <= 30:
+            size += 1
+        size += min(sessions, 5) * 0.5
+        size = max(3, min(32, size))
+
+        # Health signal
+        rhythm_days = {'daily': 1, 'weekly': 7, 'biweekly': 14, 'monthly': 30}
+        r = rhythm_days.get(w.get('rhythm', ''), 14)
+        if days <= r:
+            health = 'active'
+        elif days <= r * 2:
+            health = 'quiet'
+        else:
+            health = 'waiting'
 
         nodes.append({
-            'id': wid, 'label': wid.replace('-', ' '),
-            'domain': domain, 'type': w.get('type', 'unknown'),
-            'goal': w.get('goal', ''), 'phase': phase,
-            'rhythm': w.get('rhythm', ''), 'updated': updated,
-            'next': w.get('next', ''), 'size': size,
-            'daysSince': days_since, 'capsuleCount': capsule_count,
-            'capsuleDetails': capsule_details,
-            'sessions': sessions, 'archived': archived,
-            'isPerson': False, 'tags': w.get('tags', []),
-            'people': w.get('people', []),
-            'activeCapsule': w.get('active_capsule', ''),
+            'id': wid,
+            'label': wid.replace('-', ' '),
+            'domain': domain,
+            'type': w.get('type', 'unknown'),
+            'goal': w.get('goal', ''),
+            'phase': w.get('phase', ''),
+            'rhythm': w.get('rhythm', ''),
+            'updated': updated,
+            'next': w.get('next', ''),
+            'size': round(size, 1),
+            'daysSince': days,
+            'bundleCount': bundles,
+            'sessions': sessions,
+            'archived': archived,
+            'health': health,
+            'tags': w.get('tags', []),
+            'peopleList': w.get('people', []),
+            'linksList': w.get('links', []),
+            'parent': w.get('parent', ''),
+            'capsules': w.get('capsules', []),
+            # Enriched
+            'taskCounts': w.get('task_counts', {}),
+            'bundleSummary': w.get('bundle_summary', {}),
+            'blockers': w.get('blockers', []),
+            'sessionCount': w.get('session_count', 0),
+            'lastSession': w.get('last_session', ''),
         })
         node_ids.add(wid)
 
-    links = []
-    link_set = set()
+    # Build links from wikilinks
     for w in walnuts:
         wid = w['name']
-        if wid not in node_ids: continue
+        if wid not in node_ids:
+            continue
         for target in w.get('links', []):
             if target in node_ids and target != wid:
                 key = tuple(sorted([wid, target]))
                 if key not in link_set:
-                    links.append({'source': wid, 'target': target, 'type': 'link'})
+                    links.append({
+                        'source': wid, 'target': target, 'type': 'link'
+                    })
                     link_set.add(key)
         parent = w.get('parent', '')
         if parent and parent in node_ids and parent != wid:
             key = tuple(sorted([wid, parent]))
             if key not in link_set:
-                links.append({'source': parent, 'target': wid, 'type': 'parent'})
+                links.append({
+                    'source': parent, 'target': wid, 'type': 'parent'
+                })
                 link_set.add(key)
 
+    # People as bridge nodes (only those connecting 2+ walnuts)
     person_to_walnuts = defaultdict(list)
     for w in walnuts:
-        if w.get('archived'): continue
+        if w.get('archived'):
+            continue
         for p in w.get('people', []):
             person_to_walnuts[p].append(w['name'])
 
@@ -114,10 +169,12 @@ def main():
         if len(connected) >= 2:
             pid = 'p-' + person.lower().replace(' ', '-').replace("'", '')
             people_nodes.append({
-                'id': pid, 'label': person, 'domain': 'people',
-                'type': 'person', 'goal': '', 'phase': '',
-                'size': 5 + min(len(connected), 6),
-                'isPerson': True, 'connects': connected,
+                'id': pid,
+                'label': person,
+                'domain': 'people',
+                'type': 'person',
+                'size': 4 + min(len(connected), 6),
+                'connects': connected,
             })
             for wid in connected:
                 if wid in node_ids:
@@ -126,74 +183,11 @@ def main():
                         'type': 'person', 'label': person,
                     })
 
-    # Central world root node — reads name from .alive/key.md at runtime
-    wr_name = 'world root'
-    wr_id = 'world-root'
-    try:
-        import re
-        key_path = os.path.join(world_root, '.alive', 'key.md')
-        if os.path.exists(key_path):
-            with open(key_path, encoding='utf-8') as f:
-                content = f.read()
-            m = re.search(r'^name:\s*(.+)$', content, re.MULTILINE)
-            if m:
-                wr_name = m.group(1).strip()
-                wr_id = wr_name.lower().replace(' ', '-')
-    except Exception:
-        pass
-
-    world_root_node = {
-        'id': wr_id, 'label': wr_name, 'domain': 'life',
-        'type': 'world', 'goal': 'Build the life, ventures, and systems that matter',
-        'phase': 'world', 'size': 24, 'special': True, 'isPerson': False,
-    }
-    world_root_links = []
-    # Connect to top-level walnuts from key.md links field
-    try:
-        key_path = os.path.join(world_root, '.alive', 'key.md')
-        if os.path.exists(key_path):
-            with open(key_path, encoding='utf-8') as f:
-                content = f.read()
-            # Parse wikilinks from links: field
-            links_match = re.search(r'^links:\s*(.+)$', content, re.MULTILINE)
-            if links_match:
-                wikilinks = re.findall(r'\[\[([^\]]+)\]\]', links_match.group(1))
-                for wl in wikilinks:
-                    if wl in node_ids:
-                        world_root_links.append({'source': wr_id, 'target': wl, 'type': 'link'})
-    except Exception:
-        pass
-    # Fallback: connect to all top-level domain folders if no links found
-    if not world_root_links:
-        for t in node_ids:
-            if t.startswith('0') and '_' in t:
-                world_root_links.append({'source': wr_id, 'target': t, 'type': 'link'})
-
-    inputs_node = {
-        'id': 'inputs', 'label': f"{stats['inputs']} inputs",
-        'domain': 'inputs', 'type': 'buffer',
-        'goal': f"{stats['inputs']} unrouted items in 03_Inbox/",
-        'phase': 'buffer', 'size': 14, 'special': True, 'isPerson': False,
-    }
-
-    all_nodes = nodes + [world_root_node, inputs_node]
-    all_links = links + world_root_links
-
-    nj = json.dumps(all_nodes, ensure_ascii=False)
-    lj = json.dumps(all_links, ensure_ascii=False)
-    pnj = json.dumps(people_nodes, ensure_ascii=False)
-    plj = json.dumps(people_links, ensure_ascii=False)
-
-    html = build_html(stats, nj, lj, pnj, plj)
-    with open(html_file, 'w', encoding='utf-8') as f:
-        f.write(html)
-
-    print(f"Graph: {html_file}")
-    print(f"Nodes: {len(all_nodes)} + {len(people_nodes)} people | "
-          f"Edges: {len(all_links)} + {len(people_links)} people")
+    return nodes, links, people_nodes, people_links
 
 
 def build_html(stats, nj, lj, pnj, plj):
+    # NOTE: the f-string uses {{ }} for literal JS braces
     return f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -201,816 +195,813 @@ def build_html(stats, nj, lj, pnj, plj):
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ALIVE Context Graph</title>
 <script src="https://d3js.org/d3.v7.min.js"></script>
-<link rel="preconnect" href="https://api.fontshare.com">
-<link href="https://api.fontshare.com/v2/css?f[]=array@400,600,700&f[]=khand@400,500,600,700&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
 * {{ margin:0; padding:0; box-sizing:border-box; }}
 
-/* ─── THEME VARIABLES ─── */
 :root {{
   --bg: #FAF8F5;
   --surface: #FFFFFF;
-  --surface-2: #F0EBE5;
-  --border: #E8E2DB;
-  --border-light: #EDE8E2;
   --text: #1A1715;
   --text-dim: #6B6560;
-  --text-muted: #8A8078;
-  --primary: #F97316;
-  --primary-dim: #F9731618;
-  --primary-glow: #F9731640;
-  --copper: #B87333;
-  --copper-dim: #B8733320;
-  --green: #22C55E;
-  --green-dark: #16A34A;
-  --cream: #FAF8F5;
-  --cream-dark: #F0EBE5;
-  --shadow: rgba(26, 23, 21, 0.06);
-  --shadow-heavy: rgba(26, 23, 21, 0.12);
-
-  /* Domain colors — light mode */
-  --c-life: #3B7DD8;
-  --c-ventures: #E86A10;
-  --c-experiments: #16A34A;
-  --c-archive: #8A8078;
-  --c-people: #8B45A6;
-  --c-inputs: #C44E3F;
-
-  /* Capsule status */
-  --cap-draft: #8A8078;
-  --cap-prototype: #E09020;
-  --cap-published: #3B7DD8;
-  --cap-done: #16A34A;
-
-  /* Graph */
-  --link-color: #1A171512;
-  --link-parent: #B8733330;
-  --link-person: #8B45A620;
-  --link-capsule: #8A807830;
-  --node-label: #1A171590;
-  --node-label-dim: #1A171540;
-  --glow-filter: drop-shadow(0 0 4px rgba(249, 115, 22, 0.4));
+  --text-muted: #9A9490;
+  --border: #E8E2DB;
+  --life: #3B82F6;
+  --ventures: #F97316;
+  --experiments: #10B981;
+  --archive: #9CA3AF;
+  --people: #8B5CF6;
 }}
 
-html.dark {{
-  --bg: #0A1F0D;
-  --surface: #14532D;
-  --surface-2: #1A3A1F;
-  --border: rgba(250, 248, 245, 0.1);
-  --border-light: rgba(250, 248, 245, 0.06);
-  --text: #FAF8F5;
-  --text-dim: #D4CFC8;
-  --text-muted: #8A8078;
-  --primary: #F97316;
-  --primary-dim: #F9731625;
-  --primary-glow: #F9731650;
-  --copper: #D4A574;
-  --copper-dim: #B8733330;
-  --shadow: rgba(0, 0, 0, 0.3);
-  --shadow-heavy: rgba(0, 0, 0, 0.5);
-
-  --c-life: #5B9DE9;
-  --c-ventures: #F97316;
-  --c-experiments: #4ADE80;
-  --c-archive: #8A8078;
-  --c-people: #B67FD0;
-  --c-inputs: #E74C3C;
-
-  --cap-draft: #8A8078;
-  --cap-prototype: #F0AD4E;
-  --cap-published: #5B9DE9;
-  --cap-done: #4ADE80;
-
-  --link-color: #FAF8F510;
-  --link-parent: #D4A57430;
-  --link-person: #B67FD020;
-  --link-capsule: #8A807830;
-  --node-label: #FAF8F580;
-  --node-label-dim: #FAF8F530;
-  --glow-filter: drop-shadow(0 0 6px rgba(249, 115, 22, 0.5));
+[data-theme="dark"] {{
+  --bg: #0F1117;
+  --surface: #1A1D27;
+  --text: #E8E2DB;
+  --text-dim: #8A8078;
+  --text-muted: #5A5550;
+  --border: #2A2D37;
+  --life: #60A5FA;
+  --ventures: #FB923C;
+  --experiments: #34D399;
+  --archive: #6B7280;
+  --people: #A78BFA;
 }}
 
 body {{
+  font-family: 'Inter', -apple-system, sans-serif;
   background: var(--bg);
   color: var(--text);
-  font-family: 'Inter', -apple-system, sans-serif;
   overflow: hidden;
-  height: 100vh; width: 100vw;
-  transition: background 0.3s, color 0.3s;
-  -webkit-font-smoothing: antialiased;
+  height: 100vh;
 }}
-svg {{ display: block; }}
 
-/* ─── HEADER ─── */
-.header {{
-  position: fixed; top:0; left:0; right:0; height: 52px;
+#header {{
+  position: fixed; top:0; left:0; right:0; z-index:100;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 20px;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 0 24px; z-index: 100;
-  transition: background 0.3s, border-color 0.3s;
+  gap: 12px;
 }}
-.header-left {{ display: flex; align-items: center; gap: 20px; }}
-.header-title {{
-  font-family: 'Array', 'Inter', sans-serif;
-  font-weight: 600; font-size: 16px; letter-spacing: 0.02em;
-  color: var(--primary);
-}}
-.header-stats {{
-  color: var(--text-muted); font-size: 11px;
-  font-family: 'Khand', monospace; font-weight: 500;
-  display: flex; gap: 16px; letter-spacing: 0.02em;
-}}
-.header-stats span {{ display: flex; align-items: center; gap: 4px; }}
-.stat-hl {{ color: var(--text-dim); }}
-.header-right {{ display: flex; align-items: center; gap: 12px; }}
 
-/* Theme toggle */
-.theme-toggle {{
-  background: var(--surface-2); border: 1px solid var(--border);
-  color: var(--text-muted); width: 36px; height: 36px;
-  border-radius: 8px; cursor: pointer; display: flex;
-  align-items: center; justify-content: center;
-  font-size: 16px; transition: all 0.2s;
-}}
-.theme-toggle:hover {{ border-color: var(--primary); color: var(--primary); }}
+#header h1 {{ font-size: 13px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; white-space: nowrap; }}
+#header .stats {{ font-size: 11px; color: var(--text-dim); white-space: nowrap; }}
 
-/* ─── SEARCH ─── */
-.search-box {{ position: fixed; top: 64px; left: 50%; transform: translateX(-50%); z-index: 100; }}
-.search-box input {{
+#controls {{
+  display: flex; gap: 6px; align-items: center; flex-wrap: wrap; justify-content: flex-end;
+}}
+
+#controls button {{
+  background: var(--surface); border: 1px solid var(--border); color: var(--text-dim);
+  padding: 3px 9px; border-radius: 4px; font-size: 11px; font-family: inherit;
+  cursor: pointer; transition: all 0.15s; white-space: nowrap;
+}}
+#controls button:hover {{ color: var(--text); border-color: var(--text-muted); }}
+#controls button.active {{ background: var(--text); color: var(--bg); border-color: var(--text); }}
+
+#search-box {{
+  position: fixed; top: 46px; right: 20px; z-index: 100; display: none;
+}}
+#search-box input {{
+  background: var(--surface); border: 1px solid var(--border); color: var(--text);
+  padding: 5px 10px; border-radius: 4px; font-size: 12px; font-family: inherit;
+  width: 220px; outline: none;
+}}
+#search-box input:focus {{ border-color: var(--ventures); }}
+
+#tooltip {{
+  position: fixed; z-index: 200;
   background: var(--surface); border: 1px solid var(--border);
-  color: var(--text); font-family: 'Khand', monospace; font-weight: 500;
-  font-size: 13px; padding: 8px 20px; border-radius: 24px;
-  width: 260px; outline: none; transition: all 0.2s;
-  box-shadow: 0 2px 8px var(--shadow);
-  letter-spacing: 0.01em;
+  border-radius: 6px; padding: 10px 14px; font-size: 12px;
+  max-width: 300px; pointer-events: none; opacity: 0;
+  transition: opacity 0.12s; box-shadow: 0 4px 16px rgba(0,0,0,0.12);
 }}
-.search-box input:focus {{
-  border-color: var(--primary);
-  box-shadow: 0 2px 16px var(--primary-glow);
-  width: 340px;
+.tt-name {{ font-weight: 600; font-size: 13px; margin-bottom: 3px; }}
+.tt-badge {{
+  display: inline-block; font-size: 9px; text-transform: uppercase;
+  letter-spacing: 0.5px; padding: 1px 5px; border-radius: 3px; margin-bottom: 5px;
 }}
-.search-box input::placeholder {{ color: var(--text-muted); }}
+.tt-goal {{ color: var(--text-dim); margin-bottom: 3px; line-height: 1.4; font-size: 11px; }}
+.tt-meta {{ color: var(--text-muted); font-size: 10px; }}
+.tt-next {{ margin-top: 5px; padding-top: 5px; border-top: 1px solid var(--border); font-size: 10px; color: var(--text-dim); }}
 
-/* ─── LEGEND ─── */
-.legend {{
-  position: fixed; bottom: 24px; left: 24px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 10px; padding: 16px 18px; z-index: 100;
-  font-size: 11px; min-width: 150px;
-  box-shadow: 0 4px 16px var(--shadow);
-  transition: background 0.3s, border-color 0.3s;
-}}
-.legend-title {{
-  font-family: 'Khand', sans-serif; font-weight: 600;
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em;
-  color: var(--text-muted); margin-bottom: 8px;
-}}
-.legend-item {{
-  display: flex; align-items: center; gap: 8px;
-  margin-bottom: 5px; cursor: default; user-select: none;
-  font-family: 'Inter', sans-serif; font-size: 11px;
-  color: var(--text-dim);
-}}
-.legend-dot {{ width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }}
-.legend-count {{
-  color: var(--text-muted); font-family: 'Khand', monospace;
-  margin-left: auto; font-size: 11px; font-weight: 500;
+.link {{ fill: none; stroke-opacity: 0.25; }}
+.link-parent {{ stroke-dasharray: 4 3; }}
+.link-person {{ stroke-dasharray: 2 2; }}
+
+.node-circle {{ cursor: pointer; transition: opacity 0.2s; }}
+.node-label {{ fill: var(--text-dim); font-size: 10px; text-anchor: middle; }}
+
+.dimmed {{ opacity: 0.06 !important; }}
+.highlighted {{ opacity: 1 !important; }}
+
+.health-active {{ stroke: #22C55E !important; }}
+.health-quiet {{ stroke: #F59E0B !important; }}
+.health-waiting {{ stroke: #EF4444 !important; }}
+
+.glow {{
+  filter: drop-shadow(0 0 4px var(--ventures));
 }}
 
-/* ─── TOOLTIP ─── */
-.tooltip {{
-  position: fixed; background: var(--surface);
-  border: 1px solid var(--border); border-radius: 12px;
-  padding: 14px 18px; max-width: 340px; z-index: 200;
-  pointer-events: none; opacity: 0; transition: opacity 0.12s;
-  font-size: 12px; box-shadow: 0 8px 32px var(--shadow-heavy);
-}}
-.tooltip.visible {{ opacity: 1; }}
-.tooltip h3 {{
-  font-family: 'Khand', sans-serif; font-weight: 600;
-  font-size: 16px; margin-bottom: 4px; color: var(--text);
-}}
-.badge {{
-  display: inline-block; font-family: 'Khand', monospace;
-  font-size: 10px; font-weight: 500; padding: 2px 8px;
-  border-radius: 4px; text-transform: uppercase;
-  letter-spacing: 0.06em; margin-right: 4px; margin-bottom: 6px;
-}}
-.tooltip .goal {{ color: var(--text-dim); margin-bottom: 6px; line-height: 1.4; font-size: 11px; }}
-.tooltip .meta {{
-  font-family: 'Khand', monospace; font-size: 11px; font-weight: 500;
-  color: var(--text-muted); display: flex; flex-wrap: wrap; gap: 5px;
-}}
-.tooltip .meta span {{
-  background: var(--surface-2); padding: 2px 8px;
-  border-radius: 4px; border: 1px solid var(--border);
-}}
-.tooltip .next-action {{
-  margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border);
-  color: var(--text-dim); font-size: 11px; line-height: 1.4;
-}}
-.tooltip .next-action strong {{ color: var(--primary); font-weight: 500; }}
-
-/* ─── EDGE LABEL ─── */
-.edge-label {{
-  position: fixed; background: var(--surface-2);
-  border: 1px solid var(--border); border-radius: 4px;
-  padding: 3px 8px; font-size: 9px; font-family: 'Khand', monospace;
-  font-weight: 500; color: var(--text-muted); pointer-events: none;
-  opacity: 0; transition: opacity 0.1s; z-index: 150;
-}}
-.edge-label.visible {{ opacity: 1; }}
-
-/* ─── DETAILS PANEL ─── */
-.details {{
-  position: fixed; top: 52px; right: 0; bottom: 0; width: 360px;
-  background: var(--surface); border-left: 1px solid var(--border);
-  z-index: 90; overflow-y: auto;
-  transform: translateX(100%); transition: transform 0.25s ease, background 0.3s;
-  padding: 28px 24px;
-}}
-.details.open {{ transform: translateX(0); }}
-.details-close {{
-  position: absolute; top: 16px; right: 16px;
-  background: var(--surface-2); border: 1px solid var(--border);
-  color: var(--text-muted); cursor: pointer; font-size: 14px;
-  width: 28px; height: 28px; border-radius: 6px;
-  display: flex; align-items: center; justify-content: center;
-  transition: all 0.2s;
-}}
-.details-close:hover {{ border-color: var(--primary); color: var(--primary); }}
-.details h2 {{
-  font-family: 'Khand', sans-serif; font-weight: 600;
-  font-size: 20px; margin-bottom: 4px; padding-right: 40px;
-  color: var(--text);
-}}
-.details .badges {{ margin-bottom: 14px; }}
-.details .goal-text {{
-  color: var(--text-dim); font-size: 13px; line-height: 1.5; margin-bottom: 18px;
-}}
-.details section {{ margin-bottom: 22px; }}
-.details section h4 {{
-  font-family: 'Khand', sans-serif; font-weight: 600;
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em;
-  color: var(--text-muted); margin-bottom: 8px;
-}}
-.details .next-box {{
-  background: var(--surface-2); border: 1px solid var(--border);
-  border-radius: 8px; padding: 12px 14px;
-  font-size: 12px; color: var(--text-dim); line-height: 1.5;
-}}
-.details .next-box strong {{ color: var(--primary); }}
-.capsule-list {{ list-style: none; }}
-.capsule-list li {{
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 7px 0; border-bottom: 1px solid var(--border); font-size: 12px;
-}}
-.capsule-list li:last-child {{ border-bottom: none; }}
-.capsule-list .cap-name {{ color: var(--text); }}
-.capsule-list .cap-name.active {{ color: var(--primary); font-weight: 600; }}
-.cap-status {{
-  font-family: 'Khand', monospace; font-size: 10px; font-weight: 500;
-  padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
-  letter-spacing: 0.05em;
-}}
-.cap-status.draft {{ background: var(--surface-2); color: var(--cap-draft); }}
-.cap-status.prototype {{ background: #E0902018; color: var(--cap-prototype); }}
-.cap-status.published {{ background: #3B7DD818; color: var(--cap-published); }}
-.cap-status.done {{ background: #16A34A18; color: var(--cap-done); }}
-.people-list {{ list-style: none; }}
-.people-list li {{ font-size: 12px; color: var(--text-dim); padding: 3px 0; }}
-.tags-list {{ display: flex; flex-wrap: wrap; gap: 4px; }}
-.tags-list span {{
-  font-family: 'Khand', monospace; font-size: 11px; font-weight: 500;
-  color: var(--text-muted); background: var(--surface-2);
-  border: 1px solid var(--border); padding: 2px 8px; border-radius: 4px;
-}}
-.meta-row {{
-  display: flex; justify-content: space-between; font-size: 11px;
-  color: var(--text-muted); padding: 3px 0;
-}}
-.meta-row .value {{ color: var(--text-dim); font-family: 'Khand', monospace; font-weight: 500; }}
-
-/* ─── CONTROLS ─── */
-.controls {{
-  position: fixed; top: 64px; right: 24px;
-  display: flex; flex-direction: column; gap: 6px; z-index: 100;
-  transition: right 0.25s;
-}}
-.controls.shifted {{ right: 384px; }}
-.controls button {{
-  background: var(--surface); border: 1px solid var(--border);
-  color: var(--text-dim); font-family: 'Khand', monospace;
-  font-size: 12px; font-weight: 500; padding: 6px 14px;
-  border-radius: 8px; cursor: pointer; transition: all 0.2s;
-  text-align: left; white-space: nowrap;
-  box-shadow: 0 2px 6px var(--shadow);
-}}
-.controls button:hover {{ border-color: var(--primary); color: var(--primary); }}
-.controls button.active {{
-  background: var(--primary-dim); border-color: var(--primary); color: var(--primary);
-}}
-
-/* Domain labels */
 .domain-label {{
-  font-family: 'Array', 'Inter', sans-serif;
-  font-size: 52px; font-weight: 700;
-  pointer-events: none; text-anchor: middle;
-  dominant-baseline: central; text-transform: uppercase;
-  letter-spacing: 0.12em;
+  fill: var(--text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  opacity: 0.35;
+  pointer-events: none;
 }}
+
+#legend {{
+  position: fixed; bottom: 16px; left: 16px; z-index: 100;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 10px 14px; font-size: 11px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}}
+#legend .item {{ display: flex; align-items: center; gap: 6px; margin: 3px 0; }}
+#legend .dot {{ width: 10px; height: 10px; border-radius: 50%; }}
+
+#detail-panel {{
+  position: fixed; top: 44px; right: 0; bottom: 0; width: 320px;
+  z-index: 150; background: var(--surface); border-left: 1px solid var(--border);
+  overflow-y: auto; padding: 20px; font-size: 12px;
+  transform: translateX(100%); transition: transform 0.25s ease;
+  box-shadow: -4px 0 16px rgba(0,0,0,0.08);
+}}
+#detail-panel.open {{ transform: translateX(0); }}
+#detail-panel .dp-close {{
+  position: absolute; top: 12px; right: 12px; cursor: pointer;
+  background: none; border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-dim); font-size: 16px; width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: inherit;
+}}
+#detail-panel .dp-close:hover {{ color: var(--text); border-color: var(--text-muted); }}
+#detail-panel .dp-name {{ font-size: 18px; font-weight: 700; margin-bottom: 4px; padding-right: 36px; }}
+#detail-panel .dp-badges {{ display: flex; gap: 6px; margin-bottom: 12px; flex-wrap: wrap; }}
+#detail-panel .dp-badge {{
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+  padding: 2px 8px; border-radius: 4px; font-weight: 500;
+}}
+#detail-panel .dp-section {{ margin-bottom: 14px; }}
+#detail-panel .dp-section-title {{
+  font-size: 10px; text-transform: uppercase; letter-spacing: 1px;
+  color: var(--text-muted); margin-bottom: 4px; font-weight: 600;
+}}
+#detail-panel .dp-goal {{ color: var(--text-dim); line-height: 1.5; margin-bottom: 12px; }}
+#detail-panel .dp-next {{
+  background: var(--bg); border-radius: 4px; padding: 8px 10px;
+  border-left: 3px solid var(--ventures); color: var(--text-dim);
+  line-height: 1.4; margin-bottom: 12px;
+}}
+#detail-panel .dp-item {{ padding: 3px 0; color: var(--text-dim); }}
+#detail-panel .dp-item.clickable {{ cursor: pointer; color: var(--text); }}
+#detail-panel .dp-item.clickable:hover {{ text-decoration: underline; }}
+#detail-panel .dp-bundle {{
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 4px 0; border-bottom: 1px solid var(--border);
+}}
+#detail-panel .dp-bundle-status {{
+  font-size: 9px; text-transform: uppercase; padding: 1px 5px; border-radius: 3px;
+}}
+#detail-panel .dp-meta {{ color: var(--text-muted); font-size: 11px; margin-top: 12px; }}
 </style>
 </head>
 <body>
 
-<div class="header">
-  <div class="header-left">
-    <span class="header-title">ALIVE Context Graph</span>
-    <div class="header-stats">
-      <span><span class="stat-hl">{stats['walnuts']}</span> walnuts</span>
-      <span><span class="stat-hl">{stats['people']}</span> people</span>
-      <span><span class="stat-hl">{stats['capsules']}</span> capsules</span>
-      <span><span class="stat-hl">{stats['inputs']}</span> inputs</span>
-      <span><span class="stat-hl">{stats['sessions']}</span> sessions</span>
-    </div>
-  </div>
-  <div class="header-right">
-    <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle theme">
-      <span id="themeIcon">\u263C</span>
-    </button>
+<div id="header">
+  <h1>ALIVE</h1>
+  <div class="stats">{stats['walnuts']} walnuts &middot; {stats.get('capsules',0)} bundles &middot; {stats['people']} people</div>
+  <div id="controls">
+    <button id="btn-people">People</button>
+    <button id="btn-labels">Labels</button>
+    <button id="btn-archive">Archive</button>
+    <button id="btn-search">/ Search</button>
+    <button id="btn-theme">Dark</button>
   </div>
 </div>
 
-<div class="search-box">
-  <input type="text" id="searchInput" placeholder="search walnuts... ( / )" />
-</div>
-<div class="legend" id="legend"></div>
-<div class="tooltip" id="tooltip">
-  <h3 id="tipName"></h3>
-  <div id="tipBadges"></div>
-  <div class="goal" id="tipGoal"></div>
-  <div class="meta" id="tipMeta"></div>
-  <div class="next-action" id="tipNext"></div>
-</div>
-<div class="edge-label" id="edgeLabel"></div>
+<div id="search-box"><input type="text" placeholder="Search..." id="search-input"></div>
+<div id="tooltip"></div>
 
-<div class="details" id="details">
-  <button class="details-close" onclick="closeDetails()">&times;</button>
-  <div id="detailsContent"></div>
+<div id="legend">
+  <div class="item"><div class="dot" style="background:var(--life)"></div> Life</div>
+  <div class="item"><div class="dot" style="background:var(--ventures)"></div> Ventures</div>
+  <div class="item"><div class="dot" style="background:var(--experiments)"></div> Experiments</div>
+  <div class="item"><div class="dot" style="background:var(--people)"></div> People</div>
+  <div class="item"><div class="dot" style="background:var(--archive)"></div> Archive</div>
 </div>
 
-<div class="controls" id="controls">
-  <button onclick="resetView()">reset view</button>
-  <button onclick="togglePeople()" id="btnPeople">show people</button>
-  <button onclick="toggleLabels()" id="btnLabels" class="active">labels on</button>
-  <button onclick="toggleArchive()" id="btnArchive">show archive</button>
-  <button onclick="clusterByDomain()" id="btnCluster">cluster</button>
+<div id="detail-panel">
+  <button class="dp-close" onclick="closePanel()">&times;</button>
+  <div id="dp-content"></div>
 </div>
 
 <svg id="graph"></svg>
 
 <script>
-// ─── DATA ───
-const walnutNodes = {nj};
-const walnutLinks = {lj};
-const peopleNodesData = {pnj};
-const peopleLinksData = {plj};
+const rawNodes = {nj};
+const rawLinks = {lj};
+const rawPeopleNodes = {pnj};
+const rawPeopleLinks = {plj};
 
-// ─── THEME ───
+let showPeople = false;
+let showLabels = true;
+let showArchive = false;
 let isDark = false;
+let pinnedNode = null;
 
-// Domain colors per theme
-const themes = {{
-  light: {{
-    life: "#3B7DD8", ventures: "#E86A10", experiments: "#16A34A",
-    archive: "#8A8078", people: "#8B45A6", inputs: "#C44E3F",
-    capDraft: "#8A8078", capPrototype: "#E09020", capPublished: "#3B7DD8", capDone: "#16A34A",
-    linkColor: "#1A171510", linkParent: "#B8733330", linkPerson: "#8B45A618", linkCapsule: "#8A807825",
-    nodeLabel: "#1A171585", nodeLabelDim: "#1A171535", nodeLabelPerson: "#8B45A650",
-    nodeLabelSpecial: "#E86A10", nodeLabelCapsule: "#8A807880",
-    domainLabelFill: "#1A171506",
-    benFill: "#F97316", benStroke: "#E86A10",
-  }},
-  dark: {{
-    life: "#5B9DE9", ventures: "#F97316", experiments: "#4ADE80",
-    archive: "#8A8078", people: "#B67FD0", inputs: "#E74C3C",
-    capDraft: "#8A8078", capPrototype: "#F0AD4E", capPublished: "#5B9DE9", capDone: "#4ADE80",
-    linkColor: "#FAF8F50C", linkParent: "#D4A57430", linkPerson: "#B67FD018", linkCapsule: "#8A807825",
-    nodeLabel: "#FAF8F580", nodeLabelDim: "#FAF8F530", nodeLabelPerson: "#B67FD060",
-    nodeLabelSpecial: "#D4A574", nodeLabelCapsule: "#8A807890",
-    domainLabelFill: "#FAF8F506",
-    benFill: "#F97316", benStroke: "#D4A574",
-  }},
+const domainColorVar = {{
+  life: '--life', ventures: '--ventures', experiments: '--experiments',
+  archive: '--archive', people: '--people',
 }};
 
-function T() {{ return themes[isDark ? 'dark' : 'light']; }}
-
-function toggleTheme() {{
-  isDark = !isDark;
-  document.documentElement.classList.toggle('dark', isDark);
-  document.getElementById('themeIcon').textContent = isDark ? '\u263E' : '\u263C';
-  localStorage.setItem('walnut-graph-theme', isDark ? 'dark' : 'light');
-  render();
+function dc(domain) {{
+  const v = domainColorVar[domain] || '--ventures';
+  return getComputedStyle(document.documentElement).getPropertyValue(v).trim();
 }}
 
-// Restore saved theme
-if (localStorage.getItem('walnut-graph-theme') === 'dark') {{
-  isDark = true;
-  document.documentElement.classList.add('dark');
-  document.getElementById('themeIcon').textContent = '\u263E';
+// ─── Domain gravity targets (spread around center) ───
+const domainAngle = {{ life: -90, ventures: 30, experiments: 150, archive: 210, people: -30 }};
+function domainTarget(domain, w, h) {{
+  const angle = (domainAngle[domain] || 0) * Math.PI / 180;
+  const r = Math.min(w, h) * 0.22;
+  return {{ x: Math.cos(angle) * r, y: Math.sin(angle) * r }};
 }}
 
-// ─── STATE ───
-const W = window.innerWidth, H = window.innerHeight - 52;
-let showPeople = false, showLabels = true, showArchive = false, clustered = false;
-let expandedWalnuts = new Set();
-let detailsOpen = false;
-let simulation;
+// ─── Setup ───
+const width = window.innerWidth;
+const height = window.innerHeight - 44;
 
-// ─── BUILD GRAPH ───
+const svg = d3.select('#graph')
+  .attr('width', width).attr('height', height);
+
+const zoomG = svg.append('g');
+const domainLabelG = zoomG.append('g').attr('class', 'domain-labels');
+const linkG = zoomG.append('g').attr('class', 'links');
+const nodeG = zoomG.append('g').attr('class', 'nodes');
+
+const zoom = d3.zoom()
+  .scaleExtent([0.2, 5])
+  .on('zoom', (e) => zoomG.attr('transform', e.transform));
+svg.call(zoom);
+svg.call(zoom.transform, d3.zoomIdentity.translate(width/2, height/2 + 22));
+
+// ─── Build simulation ───
+let simulation, nodeEls, linkEls, labelEls;
+
 function buildGraph() {{
-  let nodes = walnutNodes.filter(n => showArchive || !n.archived).map(n => ({{...n}}));
-  let links = walnutLinks.map(l => ({{source:l.source, target:l.target, type:l.type, label:l.label||l.type}}));
-  const nodeIds = new Set(nodes.map(n => n.id));
-  links = links.filter(l => nodeIds.has(l.source) && nodeIds.has(l.target));
-
-  // Capsule expansion
-  expandedWalnuts.forEach(wid => {{
-    const parent = nodes.find(n => n.id === wid);
-    if (!parent || !parent.capsuleDetails) return;
-    parent.capsuleDetails.forEach(cap => {{
-      const cid = `cap:${{wid}}:${{cap.name}}`;
-      const st = cap.status || 'draft';
-      nodes.push({{
-        id: cid, label: cap.name.replace(/-/g, ' '),
-        domain: parent.domain, type: 'capsule', goal: cap.goal || '',
-        phase: st, size: parent.activeCapsule === cap.name ? 7 : 5,
-        isCapsule: true, capsuleStatus: st,
-        isActiveCapsule: parent.activeCapsule === cap.name,
-        parentWalnut: wid, isPerson: false,
-      }});
-      links.push({{ source: wid, target: cid, type: 'capsule' }});
-    }});
-  }});
+  // Filter nodes
+  let nodes = rawNodes.filter(n => showArchive || !n.archived);
+  let nodeIds = new Set(nodes.map(n => n.id));
+  let links = rawLinks.filter(l =>
+    nodeIds.has(typeof l.source === 'object' ? l.source.id : l.source) &&
+    nodeIds.has(typeof l.target === 'object' ? l.target.id : l.target)
+  );
 
   if (showPeople) {{
-    nodes = nodes.concat(peopleNodesData.map(n => ({{...n}})));
-    const ids = new Set(nodes.map(n => n.id));
-    links = links.concat(peopleLinksData.filter(l => ids.has(l.target)).map(l => ({{...l}})));
-  }}
-  return {{ nodes, links }};
-}}
-
-// ─── SVG ───
-const svg = d3.select("#graph").attr("width", W).attr("height", H).style("margin-top", "52px");
-const g = svg.append("g");
-const zoom = d3.zoom().scaleExtent([0.1, 6]).on("zoom", e => g.attr("transform", e.transform));
-svg.call(zoom);
-
-// ─── RENDER ───
-function render() {{
-  g.selectAll("*").remove();
-  svg.selectAll("defs").remove();
-  const t = T();
-  const {{ nodes, links }} = buildGraph();
-
-  simulation = d3.forceSimulation(nodes)
-    .force("link", d3.forceLink(links).id(d=>d.id)
-      .distance(d => d.type==="capsule"?28 : d.type==="person"?50 : d.type==="parent"?40 : 90)
-      .strength(d => d.type==="capsule"?0.9 : d.type==="person"?0.2 : d.type==="parent"?0.7 : 0.4))
-    .force("charge", d3.forceManyBody()
-      .strength(d => d.isCapsule?-25 : d.special?-500 : d.isPerson?-60 : d.capsuleCount>10?-350 : -180))
-    .force("center", d3.forceCenter(W/2, H/2))
-    .force("collision", d3.forceCollide().radius(d => d.size + (d.isCapsule?3:10)))
-    .force("x", d3.forceX(W/2).strength(0.02))
-    .force("y", d3.forceY(H/2).strength(0.02));
-
-  if (clustered) {{
-    const dx = {{life:W*0.15, ventures:W*0.5, experiments:W*0.85, inputs:W*0.5, archive:W*0.5}};
-    const dy = {{life:H*0.3, ventures:H*0.5, experiments:H*0.3, inputs:H*0.85, archive:H*0.85}};
-    simulation.force("x", d3.forceX(d => dx[d.domain]||W/2).strength(0.12));
-    simulation.force("y", d3.forceY(d => dy[d.domain]||H/2).strength(0.12));
-    [["LIFE","life",W*0.15,H*0.3],["VENTURES","ventures",W*0.5,H*0.5],["EXPERIMENTS","experiments",W*0.85,H*0.3]].forEach(([label,key,x,y]) => {{
-      g.append("text").attr("class","domain-label")
-        .attr("x",x).attr("y",y).text(label)
-        .attr("fill", t.domainLabelFill);
-    }});
+    nodes = [...nodes, ...rawPeopleNodes];
+    rawPeopleNodes.forEach(n => nodeIds.add(n.id));
+    links = [...links, ...rawPeopleLinks.filter(l =>
+      nodeIds.has(typeof l.source === 'object' ? l.source.id : l.source) &&
+      nodeIds.has(typeof l.target === 'object' ? l.target.id : l.target)
+    )];
   }}
 
-  // Glow filter
-  const defs = svg.append("defs");
-  const gf = defs.append("filter").attr("id","glow").attr("x","-50%").attr("y","-50%").attr("width","200%").attr("height","200%");
-  gf.append("feGaussianBlur").attr("stdDeviation","4").attr("result","b");
-  gf.append("feMerge").selectAll("feMergeNode").data(["b","SourceGraphic"]).enter().append("feMergeNode").attr("in",d=>d);
+  // Adjacency map for neighbor highlighting
+  const neighbors = new Map();
+  nodes.forEach(n => neighbors.set(n.id, new Set()));
+  links.forEach(l => {{
+    const s = typeof l.source === 'object' ? l.source.id : l.source;
+    const t = typeof l.target === 'object' ? l.target.id : l.target;
+    if (neighbors.has(s)) neighbors.get(s).add(t);
+    if (neighbors.has(t)) neighbors.get(t).add(s);
+  }});
+
+  // Clear
+  linkG.selectAll('*').remove();
+  nodeG.selectAll('*').remove();
+  domainLabelG.selectAll('*').remove();
+
+  // Domain region labels
+  const domainNames = {{ life: 'Life', ventures: 'Ventures', experiments: 'Experiments', people: 'People', archive: 'Archive' }};
+  Object.entries(domainAngle).forEach(([domain, angle]) => {{
+    if (!showArchive && domain === 'archive') return;
+    const t = domainTarget(domain, width, height);
+    domainLabelG.append('text')
+      .attr('class', 'domain-label')
+      .attr('x', t.x).attr('y', t.y - Math.min(width, height) * 0.16)
+      .attr('text-anchor', 'middle')
+      .attr('fill', dc(domain))
+      .text(domainNames[domain] || domain);
+  }});
 
   // Links
-  const linkEl = g.append("g").selectAll("line").data(links).enter().append("line")
-    .attr("stroke", d => {{
-      if (d.type==="capsule") return t.linkCapsule;
-      if (d.type==="person") return t.linkPerson;
-      if (d.type==="parent") return t.linkParent;
-      return t.linkColor;
+  linkEls = linkG.selectAll('line')
+    .data(links)
+    .join('line')
+    .attr('class', d => `link ${{d.type === 'parent' ? 'link-parent' : d.type === 'person' ? 'link-person' : ''}}`)
+    .attr('stroke', d => {{
+      if (d.type === 'person') return dc('people');
+      return isDark ? '#555' : '#ccc';
     }})
-    .attr("stroke-width", d => d.type==="parent"?1.5 : d.type==="person"?0.5 : 0.8)
-    .attr("stroke-dasharray", d => d.type==="person"?"2,4" : d.type==="parent"?"4,3" : "none")
-    .style("cursor", "pointer")
-    .on("mouseover", showEdgeLabel).on("mouseout", hideEdgeLabel);
+    .attr('stroke-width', d => d.type === 'parent' ? 1.5 : 1);
 
-  // Capsule glow rings
-  g.append("g").selectAll("circle").data(nodes.filter(n=>n.capsuleCount>5&&!n.isCapsule))
-    .enter().append("circle").attr("class","glow-ring")
-    .attr("r", d=>d.size+6).attr("fill","none")
-    .attr("stroke", d=>t[d.domain]||t.archive)
-    .attr("stroke-width",1).attr("stroke-opacity",0.2);
+  // Node groups
+  const ng = nodeG.selectAll('g')
+    .data(nodes, d => d.id)
+    .join('g')
+    .attr('class', 'node');
 
-  // Nodes
-  const nodeEl = g.append("g").selectAll("circle").data(nodes).enter().append("circle")
-    .attr("r", d=>d.size)
-    .attr("fill", d => {{
-      if (d.isCapsule) {{ const cs = {{draft:t.capDraft, prototype:t.capPrototype, published:t.capPublished, done:t.capDone}}; return cs[d.capsuleStatus]||t.capDraft; }}
-      if (d.special && d.special) return t.benFill;
-      if (d.isPerson) return t.people;
-      return t[d.domain] || t.archive;
+  // Circles with health indicators
+  ng.append('circle')
+    .attr('class', d => {{
+      let cls = 'node-circle';
+      if (d.health && !d.archived) cls += ` health-${{d.health}}`;
+      if (d.daysSince !== undefined && d.daysSince <= 3) cls += ' glow';
+      return cls;
     }})
-    .attr("fill-opacity", d => {{
-      if (d.isCapsule) return d.isActiveCapsule ? 0.9 : 0.55;
-      if (d.special) return 1;
-      if (d.archived||d.phase==="dead") return 0.15;
-      if (d.daysSince>21) return 0.35;
-      if (d.daysSince>14) return 0.5;
-      if (d.daysSince>7) return 0.65;
-      return 0.9;
+    .attr('r', d => d.size)
+    .attr('fill', d => {{
+      const c = dc(d.domain);
+      if (d.archived) return c + '30';
+      if (d.type === 'person') return c + '50';
+      // Opacity by recency
+      if (d.daysSince <= 7) return c + 'DD';
+      if (d.daysSince <= 30) return c + '99';
+      return c + '55';
     }})
-    .attr("stroke", d => {{
-      if (d.isCapsule && d.isActiveCapsule) return t[`cap${{d.capsuleStatus?.charAt(0).toUpperCase()}}${{d.capsuleStatus?.slice(1)}}`] || "#fff";
-      if (d.special && d.special) return t.benStroke;
-      if (!d.isCapsule && d.daysSince<=1) return t.benFill;
-      if (!d.isCapsule && d.capsuleCount>10) return t[d.domain]||t.archive;
-      return "transparent";
+    .attr('stroke', d => {{
+      if (d.health === 'active' && !d.archived) return '#22C55E';
+      if (d.health === 'quiet' && !d.archived) return '#F59E0B';
+      if (d.health === 'waiting' && !d.archived) return '#EF4444';
+      return dc(d.domain);
     }})
-    .attr("stroke-width", d => {{
-      if (d.isCapsule&&d.isActiveCapsule) return 1.5;
-      if (d.special) return 2.5;
-      if (d.daysSince<=1) return 2;
-      if (d.capsuleCount>10) return 1.5;
-      return 0;
+    .attr('stroke-width', d => {{
+      if (d.archived) return 0.5;
+      if (d.health === 'active') return 2.5;
+      if (d.health === 'quiet') return 2;
+      if (d.health === 'waiting') return 2;
+      return 1;
     }})
-    .attr("filter", d => (!d.isCapsule&&d.daysSince<=1) ? "url(#glow)" : "none")
-    .style("cursor","pointer")
-    .call(d3.drag().on("start",ds).on("drag",dd).on("end",de))
-    .on("mouseover", showTooltip).on("mouseout", hideTooltip)
-    .on("click", handleClick);
+    .attr('stroke-opacity', d => d.archived ? 0.2 : 0.8);
+
+  // Bundle count badge for nodes with bundles
+  ng.filter(d => d.bundleCount > 0 && !d.archived)
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', '0.35em')
+    .attr('font-size', d => Math.max(7, Math.min(10, d.size * 0.6)) + 'px')
+    .attr('font-weight', '700')
+    .attr('fill', '#fff')
+    .text(d => d.bundleCount);
+
+  // Urgent task indicator (red dot top-right)
+  ng.filter(d => d.taskCounts && d.taskCounts.urgent > 0)
+    .append('circle')
+    .attr('cx', d => d.size * 0.6)
+    .attr('cy', d => -d.size * 0.6)
+    .attr('r', 4)
+    .attr('fill', '#EF4444')
+    .attr('stroke', isDark ? '#0F1117' : '#FAF8F5')
+    .attr('stroke-width', 1.5);
+
+  // Blocker indicator (amber triangle)
+  ng.filter(d => d.blockers && d.blockers.length > 0)
+    .append('polygon')
+    .attr('points', d => {{
+      const x = -d.size * 0.6;
+      const y = -d.size * 0.6;
+      return `${{x}},${{y-5}} ${{x-4}},${{y+3}} ${{x+4}},${{y+3}}`;
+    }})
+    .attr('fill', '#F59E0B');
 
   // Labels
-  const labelEl = g.append("g").selectAll("text").data(nodes).enter().append("text")
-    .text(d => d.label)
-    .attr("font-size", d => d.isCapsule?8 : d.special?14 : d.isPerson?9 : d.capsuleCount>10?11 : d.size>=12?10 : 9)
-    .attr("fill", d => {{
-      if (d.isCapsule) return t.nodeLabelCapsule;
-      if (d.special) return t.nodeLabelSpecial;
-      if (d.isPerson) return t.nodeLabelPerson;
-      if (d.archived) return t.nodeLabelDim;
-      return t.nodeLabel;
+  labelEls = ng.append('text')
+    .attr('class', 'node-label')
+    .attr('dy', d => d.size + 12)
+    .attr('font-size', d => {{
+      if (d.size >= 14) return '11px';
+      if (d.size >= 8) return '9px';
+      return '8px';
     }})
-    .attr("font-family", d => d.special ? "'Array', 'Inter', sans-serif" : "'Inter', sans-serif")
-    .attr("font-weight", d => (d.special||d.capsuleCount>10) ? 600 : 400)
-    .attr("text-anchor","middle")
-    .attr("dy", d => d.size + (d.isCapsule?10:14))
-    .style("pointer-events","none")
-    .style("display", showLabels ? "block" : "none");
+    .attr('font-weight', d => d.size >= 12 ? '500' : '400')
+    .attr('opacity', d => {{
+      if (!showLabels) return 0;
+      if (d.size >= 10) return 1;
+      return 0;
+    }})
+    .text(d => {{
+      const name = d.label;
+      if (d.size < 8 && name.length > 12) return name.slice(0,10) + '..';
+      return name;
+    }});
 
-  simulation.on("tick", () => {{
-    linkEl.attr("x1",d=>d.source.x).attr("y1",d=>d.source.y).attr("x2",d=>d.target.x).attr("y2",d=>d.target.y);
-    nodeEl.attr("cx",d=>d.x).attr("cy",d=>d.y);
-    labelEl.attr("x",d=>d.x).attr("y",d=>d.y);
-    g.selectAll(".glow-ring").attr("cx",d=>d.x).attr("cy",d=>d.y);
+  nodeEls = ng;
+
+  // ─── Hover: neighborhood highlight ───
+  const tooltip = d3.select('#tooltip');
+
+  ng.on('mouseenter', function(event, d) {{
+    if (pinnedNode) return;
+    highlightNeighbors(d, neighbors);
+    showTooltip(event, d);
+  }})
+  .on('mousemove', (event) => {{
+    tooltip.style('left', (event.clientX + 14) + 'px')
+           .style('top', (event.clientY - 8) + 'px');
+  }})
+  .on('mouseleave', function() {{
+    if (pinnedNode) return;
+    clearHighlight();
+    tooltip.style('opacity', 0);
+  }})
+  .on('click', function(event, d) {{
+    event.stopPropagation();
+    if (pinnedNode === d.id) {{
+      pinnedNode = null;
+      clearHighlight();
+      tooltip.style('opacity', 0);
+      closePanel();
+    }} else {{
+      pinnedNode = d.id;
+      highlightNeighbors(d, neighbors);
+      tooltip.style('opacity', 0);
+      openDetailPanel(d, neighbors);
+    }}
   }});
 
-  window._nodeEl=nodeEl; window._linkEl=linkEl; window._labelEl=labelEl;
-  window._nodes=nodes; window._links=links;
-}}
-
-// ─── DRAG ───
-function ds(e,d) {{ if(!e.active) simulation.alphaTarget(0.3).restart(); d.fx=d.x; d.fy=d.y; }}
-function dd(e,d) {{ d.fx=e.x; d.fy=e.y; }}
-function de(e,d) {{ if(!e.active) simulation.alphaTarget(0); d.fx=null; d.fy=null; }}
-
-// ─── TOOLTIP ───
-const tip = document.getElementById("tooltip");
-function showTooltip(event, d) {{
-  const t = T();
-  document.getElementById("tipName").textContent = d.label;
-  const badges = document.getElementById("tipBadges");
-  badges.innerHTML = "";
-  if (d.domain && !d.isCapsule) {{
-    const c = t[d.domain]||t.archive;
-    badges.innerHTML += `<span class="badge" style="background:${{c}}18;color:${{c}}">${{d.domain}}</span>`;
-  }}
-  if (d.phase) {{
-    const phaseColors = {{building:"#16A34A",active:"#3B7DD8",launching:"#F97316",legacy:"#8A8078","pre-launch":"#E09020",onboarding:"#5BC0DE",starting:"#8A8078",dead:"#8A8078",marinating:"#8B45A6",planning:"#5BC0DE",exploring:"#5BC0DE",placeholder:"#8A8078",ready:"#16A34A",review:"#E09020","retainer-pending":"#E09020",buffer:"#C44E3F",world:"#F97316",research:"#5BC0DE",complete:"#16A34A",waiting:"#E09020",unknown:"#8A8078"}};
-    let pc = phaseColors[d.phase]||"#8A8078";
-    if (d.isCapsule) pc = {{draft:t.capDraft,prototype:t.capPrototype,published:t.capPublished,done:t.capDone}}[d.phase]||pc;
-    badges.innerHTML += `<span class="badge" style="background:${{pc}}18;color:${{pc}}">${{d.phase}}</span>`;
-  }}
-  document.getElementById("tipGoal").textContent = d.goal || "";
-  const meta = document.getElementById("tipMeta");
-  meta.innerHTML = "";
-  if (d.rhythm) meta.innerHTML += `<span>${{d.rhythm}}</span>`;
-  if (d.updated) meta.innerHTML += `<span>${{d.updated}}</span>`;
-  if (d.capsuleCount) meta.innerHTML += `<span>${{d.capsuleCount}} capsules</span>`;
-  if (d.sessions) meta.innerHTML += `<span>${{d.sessions}} sessions</span>`;
-  if (d.connects) meta.innerHTML += `<span>connects ${{d.connects.length}}</span>`;
-  const nx = document.getElementById("tipNext");
-  nx.innerHTML = d.next ? `<strong>next:</strong> ${{d.next}}` : "";
-  nx.style.display = d.next ? "block" : "none";
-  tip.classList.add("visible");
-  tip.style.left = Math.min(event.pageX+16, W-360) + "px";
-  tip.style.top = Math.min(event.pageY-10, H-200) + "px";
-  highlightConnected(d);
-}}
-function hideTooltip() {{ tip.classList.remove("visible"); resetHighlight(); }}
-
-function highlightConnected(d) {{
-  const c = new Set([d.id]);
-  window._links.forEach(l => {{
-    const s=l.source.id||l.source, t=l.target.id||l.target;
-    if(s===d.id) c.add(t); if(t===d.id) c.add(s);
+  svg.on('click', () => {{
+    pinnedNode = null;
+    clearHighlight();
+    tooltip.style('opacity', 0);
+    closePanel();
   }});
-  window._nodeEl.attr("fill-opacity", n => c.has(n.id) ? (n.special?1:0.95) : 0.06);
-  window._labelEl.attr("fill-opacity", n => c.has(n.id) ? 1 : 0.04);
-  window._linkEl.attr("stroke-opacity", l => {{
-    const s=l.source.id||l.source, t=l.target.id||l.target;
-    return (c.has(s)&&c.has(t)) ? 0.7 : 0.02;
-  }});
-}}
-function resetHighlight() {{
-  window._nodeEl.attr("fill-opacity", d => {{
-    if(d.isCapsule) return d.isActiveCapsule?0.9:0.55;
-    if(d.special) return 1;
-    if(d.archived||d.phase==="dead") return 0.15;
-    if(d.daysSince>21) return 0.35; if(d.daysSince>14) return 0.5;
-    if(d.daysSince>7) return 0.65; return 0.9;
-  }});
-  window._labelEl.attr("fill-opacity",1);
-  window._linkEl.attr("stroke-opacity",1);
-}}
 
-// ─── EDGE LABEL ───
-const edgeLbl = document.getElementById("edgeLabel");
-function showEdgeLabel(event, d) {{
-  const labels = {{link:"linked", parent:"parent \u2192 child", person:d.label||"person", capsule:"capsule"}};
-  edgeLbl.textContent = labels[d.type]||d.type;
-  edgeLbl.classList.add("visible");
-  edgeLbl.style.left = event.pageX+"px";
-  edgeLbl.style.top = (event.pageY-24)+"px";
-}}
-function hideEdgeLabel() {{ edgeLbl.classList.remove("visible"); }}
+  // ─── Drag ───
+  ng.call(d3.drag()
+    .on('start', (event, d) => {{
+      if (!event.active) simulation.alphaTarget(0.15).restart();
+      d.fx = d.x; d.fy = d.y;
+    }})
+    .on('drag', (event, d) => {{
+      d.fx = event.x; d.fy = event.y;
+    }})
+    .on('end', (event, d) => {{
+      if (!event.active) simulation.alphaTarget(0);
+      d.fx = null; d.fy = null;
+    }})
+  );
 
-// ─── CLICK ───
-function handleClick(event, d) {{
-  event.stopPropagation();
-  if (!d.isCapsule && !d.isPerson && !d.special && d.capsuleCount > 0) {{
-    if (expandedWalnuts.has(d.id)) expandedWalnuts.delete(d.id);
-    else expandedWalnuts.add(d.id);
-    render();
+  // ─── Simulation ───
+  simulation = d3.forceSimulation(nodes)
+    .force('charge', d3.forceManyBody()
+      .strength(d => d.archived ? -30 : d.type === 'person' ? -40 : -120))
+    .force('link', d3.forceLink(links).id(d => d.id)
+      .distance(d => d.type === 'parent' ? 35 : d.type === 'person' ? 50 : 55)
+      .strength(d => d.type === 'parent' ? 0.7 : 0.2))
+    .force('collide', d3.forceCollide()
+      .radius(d => d.size + 3).strength(0.8))
+    .force('x', d3.forceX()
+      .x(d => domainTarget(d.domain, width, height).x)
+      .strength(d => d.parent ? 0.02 : 0.06))
+    .force('y', d3.forceY()
+      .y(d => domainTarget(d.domain, width, height).y)
+      .strength(d => d.parent ? 0.02 : 0.06))
+    .alphaDecay(0.02)
+    .on('tick', () => {{
+      linkEls
+        .attr('x1', d => d.source.x).attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+      nodeEls.attr('transform', d => `translate(${{d.x}},${{d.y}})`);
+    }});
+
+  function highlightNeighbors(d, nbrs) {{
+    const connected = nbrs.get(d.id) || new Set();
+    connected.add(d.id);
+
+    nodeEls.select('circle')
+      .classed('dimmed', n => !connected.has(n.id))
+      .classed('highlighted', n => connected.has(n.id));
+
+    labelEls
+      .classed('dimmed', n => !connected.has(n.id))
+      .classed('highlighted', n => connected.has(n.id))
+      .attr('opacity', n => {{
+        if (connected.has(n.id)) return 1;
+        return 0.06;
+      }});
+
+    linkEls
+      .classed('dimmed', l => {{
+        const s = typeof l.source === 'object' ? l.source.id : l.source;
+        const t = typeof l.target === 'object' ? l.target.id : l.target;
+        return !(connected.has(s) && connected.has(t));
+      }})
+      .classed('highlighted', l => {{
+        const s = typeof l.source === 'object' ? l.source.id : l.source;
+        const t = typeof l.target === 'object' ? l.target.id : l.target;
+        return connected.has(s) && connected.has(t);
+      }})
+      .attr('stroke-opacity', l => {{
+        const s = typeof l.source === 'object' ? l.source.id : l.source;
+        const t = typeof l.target === 'object' ? l.target.id : l.target;
+        return (connected.has(s) && connected.has(t)) ? 0.7 : 0.03;
+      }});
   }}
-  showDetails(d);
+
+  function clearHighlight() {{
+    nodeEls.select('circle').classed('dimmed', false).classed('highlighted', false);
+    labelEls.classed('dimmed', false).classed('highlighted', false)
+      .attr('opacity', d => {{
+        if (!showLabels) return 0;
+        if (d.size >= 10) return 1;
+        return 0;
+      }});
+    linkEls.classed('dimmed', false).classed('highlighted', false)
+      .attr('stroke-opacity', 0.25);
+  }}
+
+  function showTooltip(event, d) {{
+    let html = `<div class="tt-name">${{d.label}}</div>`;
+    html += `<span class="tt-badge" style="background:${{dc(d.domain)}}22;color:${{dc(d.domain)}}">${{d.type || d.domain}}</span>`;
+    if (d.goal) html += `<div class="tt-goal">${{d.goal}}</div>`;
+
+    const meta = [];
+    if (d.phase && d.phase !== 'unknown') meta.push(d.phase);
+    if (d.updated) meta.push(`${{d.updated}}`);
+    if (d.bundleCount) meta.push(`${{d.bundleCount}} bundles`);
+    if (d.sessions) meta.push(`${{d.sessions}} sessions`);
+    if (d.peopleList && d.peopleList.length) meta.push(d.peopleList.join(', '));
+    if (meta.length) html += `<div class="tt-meta">${{meta.join(' &middot; ')}}</div>`;
+    if (d.next) html += `<div class="tt-next"><b>Next:</b> ${{
+      typeof d.next === 'string' ? d.next.slice(0,100) : ''
+    }}</div>`;
+
+    tooltip.html(html).style('opacity', 1);
+  }}
 }}
 
-function showDetails(d) {{
-  const t = T();
-  const panel = document.getElementById("details");
-  let html = `<h2>${{d.label}}</h2><div class="badges">`;
-  if (d.domain && !d.isCapsule) {{
-    const c=t[d.domain]||t.archive;
-    html+=`<span class="badge" style="background:${{c}}18;color:${{c}}">${{d.domain}}</span>`;
+// ─── Detail Panel ───
+function openDetailPanel(d, nbrs) {{
+  const panel = document.getElementById('detail-panel');
+  const content = document.getElementById('dp-content');
+  const data = d;
+
+  const healthColors = {{ active: '#22C55E', quiet: '#F59E0B', waiting: '#EF4444' }};
+  const healthLabels = {{ active: 'Active', quiet: 'Quiet', waiting: 'Stale' }};
+  const statusColors = {{ draft: '#9CA3AF', prototype: '#F59E0B', published: '#3B82F6', done: '#22C55E' }};
+
+  let html = `<div class="dp-name">${{data.label}}</div>`;
+  html += `<div class="dp-badges">`;
+  html += `<span class="dp-badge" style="background:${{dc(data.domain)}}22;color:${{dc(data.domain)}}">${{data.domain}}</span>`;
+  if (data.type && data.type !== data.domain) {{
+    html += `<span class="dp-badge" style="background:var(--border);color:var(--text-dim)">${{data.type}}</span>`;
   }}
-  if (d.phase) {{
-    const pc = d.isCapsule ? ({{draft:t.capDraft,prototype:t.capPrototype,published:t.capPublished,done:t.capDone}}[d.phase]||"#8A8078") : "#8A8078";
-    html+=`<span class="badge" style="background:${{pc}}18;color:${{pc}}">${{d.phase}}</span>`;
+  if (data.health) {{
+    const hc = healthColors[data.health] || '#999';
+    html += `<span class="dp-badge" style="background:${{hc}}22;color:${{hc}}">${{healthLabels[data.health] || data.health}}</span>`;
+  }}
+  if (data.phase && data.phase !== 'unknown') {{
+    html += `<span class="dp-badge" style="background:var(--border);color:var(--text-dim)">${{data.phase}}</span>`;
   }}
   html += `</div>`;
-  if (d.goal) html+=`<div class="goal-text">${{d.goal}}</div>`;
-  html+=`<section>`;
-  if (d.rhythm) html+=`<div class="meta-row"><span>rhythm</span><span class="value">${{d.rhythm}}</span></div>`;
-  if (d.updated) html+=`<div class="meta-row"><span>updated</span><span class="value">${{d.updated}}</span></div>`;
-  if (d.daysSince!==undefined&&!d.isCapsule) html+=`<div class="meta-row"><span>days ago</span><span class="value">${{d.daysSince}}d</span></div>`;
-  if (d.sessions) html+=`<div class="meta-row"><span>sessions</span><span class="value">${{d.sessions}}</span></div>`;
-  html+=`</section>`;
-  if (d.next) html+=`<section><h4>Next Action</h4><div class="next-box"><strong>next:</strong> ${{d.next}}</div></section>`;
-  if (d.capsuleDetails && d.capsuleDetails.length) {{
-    const expanded = expandedWalnuts.has(d.id);
-    html+=`<section><h4>Capsules (${{d.capsuleDetails.length}})${{expanded?' \u2014 expanded':' \u2014 click to expand'}}</h4><ul class="capsule-list">`;
-    d.capsuleDetails.forEach(c => {{
-      const active = d.activeCapsule===c.name;
-      html+=`<li><span class="cap-name${{active?' active':''}}">${{c.name.replace(/-/g,' ')}}</span><span class="cap-status ${{c.status||'draft'}}">${{c.status||'draft'}}</span></li>`;
+
+  if (data.goal) {{
+    html += `<div class="dp-goal">${{data.goal}}</div>`;
+  }}
+
+  if (data.next) {{
+    const nextText = typeof data.next === 'string' ? data.next : (data.next.action || '');
+    if (nextText) {{
+      html += `<div class="dp-next"><strong>Next:</strong> ${{nextText.slice(0, 200)}}</div>`;
+    }}
+  }}
+
+  // Blockers
+  if (data.blockers && data.blockers.length > 0) {{
+    html += `<div class="dp-section" style="background:#EF444415;border-radius:4px;padding:8px 10px;margin-bottom:12px">`;
+    html += `<div class="dp-section-title" style="color:#EF4444">Blockers (${{data.blockers.length}})</div>`;
+    data.blockers.forEach(b => {{
+      html += `<div class="dp-item" style="color:#EF4444">${{b}}</div>`;
     }});
-    html+=`</ul></section>`;
+    html += `</div>`;
   }}
-  if (d.people && d.people.length) {{
-    html+=`<section><h4>People</h4><ul class="people-list">`;
-    d.people.forEach(p => html+=`<li>${{p}}</li>`);
-    html+=`</ul></section>`;
+
+  // Tasks summary
+  const tc = data.taskCounts || {{}};
+  if (tc.urgent || tc.active || tc.todo || tc.blocked) {{
+    html += `<div class="dp-section"><div class="dp-section-title">Tasks</div>`;
+    html += `<div style="display:flex;gap:8px;flex-wrap:wrap">`;
+    if (tc.urgent) html += `<span class="dp-badge" style="background:#EF444422;color:#EF4444">${{tc.urgent}} urgent</span>`;
+    if (tc.active) html += `<span class="dp-badge" style="background:#3B82F622;color:#3B82F6">${{tc.active}} active</span>`;
+    if (tc.todo) html += `<span class="dp-badge" style="background:var(--border);color:var(--text-dim)">${{tc.todo}} todo</span>`;
+    if (tc.blocked) html += `<span class="dp-badge" style="background:#F59E0B22;color:#F59E0B">${{tc.blocked}} blocked</span>`;
+    html += `</div></div>`;
   }}
-  if (d.connects) {{
-    html+=`<section><h4>Connects</h4><ul class="people-list">`;
-    d.connects.forEach(w => html+=`<li>${{w.replace(/-/g,' ')}}</li>`);
-    html+=`</ul></section>`;
+
+  // Bundles
+  if (data.capsules && data.capsules.length > 0) {{
+    html += `<div class="dp-section"><div class="dp-section-title">Bundles (${{data.capsules.length}})</div>`;
+    data.capsules.forEach(b => {{
+      const sc = statusColors[b.status] || '#999';
+      html += `<div class="dp-bundle"><span>${{b.name.replace(/-/g, ' ')}}</span>`;
+      html += `<span class="dp-bundle-status" style="background:${{sc}}22;color:${{sc}}">${{b.status || 'draft'}}</span></div>`;
+    }});
+    html += `</div>`;
   }}
-  if (d.tags && d.tags.length) {{
-    html+=`<section><h4>Tags</h4><div class="tags-list">`;
-    d.tags.forEach(t => html+=`<span>${{t}}</span>`);
-    html+=`</div></section>`;
+
+  // People
+  if (data.peopleList && data.peopleList.length > 0) {{
+    html += `<div class="dp-section"><div class="dp-section-title">People (${{data.peopleList.length}})</div>`;
+    data.peopleList.forEach(p => {{
+      html += `<div class="dp-item">${{p}}</div>`;
+    }});
+    html += `</div>`;
   }}
-  document.getElementById("detailsContent").innerHTML = html;
-  panel.classList.add("open");
-  document.getElementById("controls").classList.add("shifted");
-  detailsOpen = true;
+
+  // Connected walnuts (clickable)
+  const connected = nbrs.get(data.id) || new Set();
+  if (connected.size > 0) {{
+    html += `<div class="dp-section"><div class="dp-section-title">Connected (${{connected.size}})</div>`;
+    connected.forEach(cid => {{
+      html += `<div class="dp-item clickable" onclick="focusNode('${{cid}}')">${{cid.replace(/-/g, ' ')}}</div>`;
+    }});
+    html += `</div>`;
+  }}
+
+  // Tags
+  if (data.tags && data.tags.length > 0) {{
+    html += `<div class="dp-section"><div class="dp-section-title">Tags</div>`;
+    html += `<div style="display:flex;flex-wrap:wrap;gap:4px">`;
+    data.tags.forEach(t => {{
+      html += `<span class="dp-badge" style="background:var(--border);color:var(--text-dim)">${{t}}</span>`;
+    }});
+    html += `</div></div>`;
+  }}
+
+  // Meta
+  const meta = [];
+  if (data.updated) meta.push(`Updated: ${{data.updated}}`);
+  if (data.rhythm) meta.push(`Rhythm: ${{data.rhythm}}`);
+  if (data.sessions) meta.push(`Sessions: ${{data.sessions}}`);
+  if (data.bundleCount) meta.push(`Bundles: ${{data.bundleCount}}`);
+  if (data.daysSince !== undefined) meta.push(`${{data.daysSince}}d ago`);
+  if (meta.length) html += `<div class="dp-meta">${{meta.join(' &middot; ')}}</div>`;
+
+  content.innerHTML = html;
+  panel.classList.add('open');
 }}
 
-function closeDetails() {{
-  document.getElementById("details").classList.remove("open");
-  document.getElementById("controls").classList.remove("shifted");
-  detailsOpen = false;
-}}
-svg.on("click", () => {{ if(detailsOpen) closeDetails(); }});
-
-// ─── CONTROLS ───
-function resetView() {{ svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity); }}
-function togglePeople() {{
-  showPeople=!showPeople;
-  const b=document.getElementById("btnPeople");
-  b.classList.toggle("active",showPeople); b.textContent=showPeople?"hide people":"show people";
-  render();
-}}
-function toggleLabels() {{
-  showLabels=!showLabels;
-  const b=document.getElementById("btnLabels");
-  b.classList.toggle("active",showLabels); b.textContent=showLabels?"labels on":"labels off";
-  if(window._labelEl) window._labelEl.style("display",showLabels?"block":"none");
-}}
-function toggleArchive() {{
-  showArchive=!showArchive;
-  const b=document.getElementById("btnArchive");
-  b.classList.toggle("active",showArchive); b.textContent=showArchive?"hide archive":"show archive";
-  render();
-}}
-function clusterByDomain() {{
-  clustered=!clustered;
-  const b=document.getElementById("btnCluster");
-  b.classList.toggle("active",clustered); b.textContent=clustered?"organic":"cluster";
-  render();
+function closePanel() {{
+  document.getElementById('detail-panel').classList.remove('open');
 }}
 
-// ─── SEARCH ───
-const searchInput = document.getElementById("searchInput");
-searchInput.addEventListener("input", e => {{
-  const q=e.target.value.toLowerCase().trim();
-  if(!q) {{ resetHighlight(); return; }}
-  const hits=new Set();
-  walnutNodes.forEach(n => {{
-    if(n.id.includes(q)||n.label.includes(q)||(n.goal&&n.goal.toLowerCase().includes(q))
-      ||(n.tags&&n.tags.some(t=>t.includes(q)))||(n.people&&n.people.some(p=>p.toLowerCase().includes(q)))) hits.add(n.id);
+function focusNode(nodeId) {{
+  // Find and highlight the target node in the graph
+  const targetNode = nodeEls.data().find(d => d.id === nodeId);
+  if (targetNode) {{
+    pinnedNode = nodeId;
+    // Pan to the node
+    const transform = d3.zoomTransform(svg.node());
+    const x = targetNode.x * transform.k + transform.x;
+    const y = targetNode.y * transform.k + transform.y;
+    svg.transition().duration(500)
+      .call(zoom.translateTo, targetNode.x, targetNode.y);
+
+    // Build neighbors map and highlight
+    const neighbors = new Map();
+    const allNodes = nodeEls.data();
+    allNodes.forEach(n => neighbors.set(n.id, new Set()));
+    const allLinks = linkEls.data();
+    allLinks.forEach(l => {{
+      const s = typeof l.source === 'object' ? l.source.id : l.source;
+      const t = typeof l.target === 'object' ? l.target.id : l.target;
+      if (neighbors.has(s)) neighbors.get(s).add(t);
+      if (neighbors.has(t)) neighbors.get(t).add(s);
+    }});
+
+    // Trigger highlight + panel
+    const connected = neighbors.get(nodeId) || new Set();
+    connected.add(nodeId);
+    nodeEls.select('circle')
+      .classed('dimmed', n => !connected.has(n.id))
+      .classed('highlighted', n => connected.has(n.id));
+    labelEls
+      .attr('opacity', n => connected.has(n.id) ? 1 : 0.06);
+    linkEls
+      .attr('stroke-opacity', l => {{
+        const s = typeof l.source === 'object' ? l.source.id : l.source;
+        const t = typeof l.target === 'object' ? l.target.id : l.target;
+        return (connected.has(s) && connected.has(t)) ? 0.7 : 0.03;
+      }});
+
+    openDetailPanel(targetNode, neighbors);
+  }}
+}}
+
+// ─── Search (highlight without hiding) ───
+const searchInput = document.getElementById('search-input');
+searchInput.addEventListener('input', () => {{
+  const term = searchInput.value.toLowerCase();
+  if (!term) {{
+    nodeEls.select('circle').classed('dimmed', false);
+    labelEls.classed('dimmed', false).attr('opacity', d => {{
+      if (!showLabels) return 0;
+      return d.size >= 10 ? 1 : 0;
+    }});
+    linkEls.attr('stroke-opacity', 0.25);
+    return;
+  }}
+  nodeEls.select('circle').classed('dimmed', d => {{
+    const name = (d.label || '').toLowerCase();
+    const goal = (d.goal || '').toLowerCase();
+    const tags = (d.tags || []).join(' ').toLowerCase();
+    return !(name.includes(term) || goal.includes(term) || tags.includes(term));
   }});
-  window._nodeEl.attr("fill-opacity", n => hits.has(n.id)?0.95:0.04);
-  window._labelEl.attr("fill-opacity", n => hits.has(n.id)?1:0.03);
-  window._linkEl.attr("stroke-opacity", 0.02);
-}});
-searchInput.addEventListener("keydown", e => {{ if(e.key==="Escape") {{ searchInput.value=""; resetHighlight(); searchInput.blur(); }} }});
-document.addEventListener("keydown", e => {{
-  if(e.key==="/"&&document.activeElement!==searchInput) {{ e.preventDefault(); searchInput.focus(); }}
-  if(e.key==="Escape"&&detailsOpen) closeDetails();
-}});
-
-// ─── LEGEND ───
-function buildLegend() {{
-  const t = T();
-  const counts = {{}};
-  walnutNodes.forEach(n => {{ if(!n.archived) counts[n.domain]=(counts[n.domain]||0)+1; }});
-  let html = '<div class="legend-title">domains</div>';
-  [["life","Life"],["ventures","Ventures"],["experiments","Experiments"],["inputs","Inputs"],["people","People"]].forEach(([k,l]) => {{
-    html+=`<div class="legend-item"><div class="legend-dot" style="background:${{t[k]||t.archive}}"></div>${{l}}<span class="legend-count">${{counts[k]||0}}</span></div>`;
+  labelEls.attr('opacity', d => {{
+    const name = (d.label || '').toLowerCase();
+    const goal = (d.goal || '').toLowerCase();
+    return (name.includes(term) || goal.includes(term)) ? 1 : 0.06;
   }});
-  html+='<div style="margin:10px 0;border-top:1px solid var(--border)"></div><div class="legend-title">capsules</div>';
-  [["draft","Draft",t.capDraft],["prototype","Prototype",t.capPrototype],["done","Done",t.capDone]].forEach(([k,l,c]) => {{
-    html+=`<div class="legend-item"><div class="legend-dot" style="background:${{c}}"></div>${{l}}</div>`;
-  }});
-  html+='<div style="margin:10px 0;border-top:1px solid var(--border)"></div>';
-  html+='<div style="font-size:9px;color:var(--text-muted)">/ search \u00b7 click expand \u00b7 esc close</div>';
-  document.getElementById("legend").innerHTML = html;
-}}
-
-// ─── INIT ───
-buildLegend();
-render();
-
-window.addEventListener("resize", () => {{
-  const w=window.innerWidth, h=window.innerHeight-52;
-  svg.attr("width",w).attr("height",h);
-  if(simulation) {{ simulation.force("center",d3.forceCenter(w/2,h/2)); simulation.alpha(0.3).restart(); }}
 }});
+
+// ─── Controls ───
+document.getElementById('btn-people').addEventListener('click', function() {{
+  showPeople = !showPeople;
+  this.classList.toggle('active', showPeople);
+  buildGraph();
+}});
+
+document.getElementById('btn-labels').addEventListener('click', function() {{
+  showLabels = !showLabels;
+  this.classList.toggle('active', !showLabels);
+  this.textContent = showLabels ? 'Labels' : 'No Labels';
+  if (labelEls) labelEls.attr('opacity', d => {{
+    if (!showLabels) return 0;
+    return d.size >= 10 ? 1 : 0;
+  }});
+}});
+
+document.getElementById('btn-archive').addEventListener('click', function() {{
+  showArchive = !showArchive;
+  this.classList.toggle('active', showArchive);
+  buildGraph();
+}});
+
+const searchBox = document.getElementById('search-box');
+document.getElementById('btn-search').addEventListener('click', () => {{
+  searchBox.style.display = searchBox.style.display === 'none' ? 'block' : 'none';
+  if (searchBox.style.display === 'block') searchInput.focus();
+}});
+
+document.getElementById('btn-theme').addEventListener('click', function() {{
+  isDark = !isDark;
+  document.documentElement.setAttribute('data-theme', isDark ? 'dark' : '');
+  this.textContent = isDark ? 'Light' : 'Dark';
+  buildGraph();
+}});
+
+document.addEventListener('keydown', (e) => {{
+  if (e.key === '/') {{ e.preventDefault(); searchBox.style.display = 'block'; searchInput.focus(); }}
+  if (e.key === 'Escape') {{
+    searchBox.style.display = 'none';
+    searchInput.value = '';
+    pinnedNode = null;
+    if (nodeEls) {{
+      nodeEls.select('circle').classed('dimmed', false);
+      labelEls.classed('dimmed', false).attr('opacity', d => {{
+        if (!showLabels) return 0;
+        return d.size >= 10 ? 1 : 0;
+      }});
+      linkEls.attr('stroke-opacity', 0.25);
+    }}
+    d3.select('#tooltip').style('opacity', 0);
+  }}
+}});
+
+window.addEventListener('resize', () => {{
+  const w = window.innerWidth, h = window.innerHeight - 44;
+  svg.attr('width', w).attr('height', h);
+}});
+
+// ─── Semantic zoom: show/hide labels based on zoom level ───
+svg.call(zoom.on('zoom', (e) => {{
+  zoomG.attr('transform', e.transform);
+  const k = e.transform.k;
+  if (labelEls) {{
+    labelEls.attr('opacity', d => {{
+      if (!showLabels) return 0;
+      if (d.size * k >= 8) return 1;
+      if (d.size * k >= 5) return 0.5;
+      return 0;
+    }});
+  }}
+}}));
+
+// ─── Init ───
+buildGraph();
 </script>
 </body>
 </html>'''

--- a/plugins/alive/scripts/generate-index.py
+++ b/plugins/alive/scripts/generate-index.py
@@ -460,6 +460,79 @@ def main():
         world_sq_count = len([f for f in os.listdir(world_sq_dir)
                               if f.endswith('.yaml')])
 
+    # ─── Recent sessions + unsigned stash count ───
+    recent_sessions = []
+    unsigned_with_stash = 0
+    if os.path.isdir(world_sq_dir):
+        sq_files = [f for f in os.listdir(world_sq_dir) if f.endswith('.yaml')]
+        sq_files.sort(
+            key=lambda f: os.path.getmtime(os.path.join(world_sq_dir, f)),
+            reverse=True
+        )
+
+        def extract_sq_field(content, field):
+            """Extract a field value from squirrel YAML via regex."""
+            m = re.search(r'^' + re.escape(field) + r'\s*:\s*(.*)', content, re.MULTILINE)
+            if not m:
+                return ''
+            val = m.group(1).strip()
+            if len(val) >= 2 and ((val[0] == '"' and val[-1] == '"') or
+                                   (val[0] == "'" and val[-1] == "'")):
+                val = val[1:-1]
+            return val
+
+        for sq_file in sq_files:
+            sq_path = os.path.join(world_sq_dir, sq_file)
+            try:
+                with open(sq_path, 'r', encoding='utf-8') as sf:
+                    sq_content = sf.read()
+            except (IOError, UnicodeDecodeError):
+                continue
+
+            saves_str = extract_sq_field(sq_content, 'saves')
+            saves_val = 0
+            try:
+                saves_val = int(saves_str)
+            except (ValueError, TypeError):
+                pass
+
+            has_empty_stash = bool(re.search(r'^stash\s*:\s*\[\s*\]\s*$', sq_content, re.MULTILINE))
+            has_stash_key = bool(re.search(r'^stash\s*:', sq_content, re.MULTILINE))
+            if saves_val == 0 and has_stash_key and not has_empty_stash:
+                stash_m = re.search(r'^stash\s*:.*\n(\s+-\s)', sq_content, re.MULTILINE)
+                if stash_m:
+                    unsigned_with_stash += 1
+
+            if len(recent_sessions) < 10:
+                session_id = extract_sq_field(sq_content, 'session_id')
+                walnut_name = extract_sq_field(sq_content, 'walnut')
+                started = extract_sq_field(sq_content, 'started')
+                recovery = extract_sq_field(sq_content, 'recovery_state')
+                bundle = extract_sq_field(sq_content, 'bundle')
+                tags_raw = extract_sq_field(sq_content, 'tags')
+
+                date = ''
+                if started:
+                    date_m = re.match(r'(\d{4}-\d{2}-\d{2})', started)
+                    if date_m:
+                        date = date_m.group(1)
+
+                tags_list = parse_inline_list(tags_raw)
+
+                entry = {
+                    'squirrel': session_id[:8] if session_id else sq_file[:8],
+                    'walnut': walnut_name if walnut_name and walnut_name != 'null' else '',
+                    'date': date,
+                    'saves': saves_val,
+                    'summary': recovery,
+                }
+                if bundle:
+                    entry['bundle'] = bundle
+                if tags_list:
+                    entry['tags'] = tags_list
+
+                recent_sessions.append(entry)
+
     # Inputs count
     inputs_dir = os.path.join(world_root, '03_Inbox')
     input_count = 0
@@ -541,6 +614,25 @@ def main():
         lines.append(f'    path: {yaml_escape(p["path"])}')
         lines.append(f'    updated: {yaml_escape(p["updated"] or "unknown")}')
 
+    lines.append('')
+    lines.append('recent_sessions:')
+    if recent_sessions:
+        for rs in recent_sessions:
+            lines.append(f'  - squirrel: {yaml_escape(rs.get("squirrel", ""))}')
+            lines.append(f'    walnut: {yaml_escape(rs.get("walnut", ""))}')
+            lines.append(f'    date: {yaml_escape(rs.get("date", ""))}')
+            if rs.get('bundle'):
+                lines.append(f'    bundle: {yaml_escape(rs["bundle"])}')
+            lines.append(f'    saves: {rs.get("saves", 0)}')
+            if rs.get('summary'):
+                lines.append(f'    summary: {yaml_escape(rs["summary"])}')
+            if rs.get('tags'):
+                tags_str = ', '.join(rs['tags'])
+                lines.append(f'    tags: [{tags_str}]')
+    else:
+        lines.append('  # no recent sessions')
+    lines.append(f'unsigned_with_stash: {unsigned_with_stash}')
+
     output = '\n'.join(lines) + '\n'
 
     os.makedirs(alive_dir, exist_ok=True)
@@ -553,6 +645,11 @@ def main():
         return {k: v for k, v in entry.items()
                 if v and v != [] and v != 0 and v != False}
 
+    def clean_session(entry):
+        """Clean session entry but preserve saves: 0 since it's meaningful."""
+        return {k: v for k, v in entry.items()
+                if k == 'saves' or (v and v != [] and v is not False)}
+
     json_data = {
         'generated': timestamp,
         'stats': {
@@ -561,9 +658,11 @@ def main():
             'capsules': total_capsules,
             'sessions': world_sq_count,
             'inputs': input_count,
+            'unsigned_with_stash': unsigned_with_stash,
         },
         'walnuts': [clean(w) for w in walnuts],
         'people': [clean(p) for p in people],
+        'recent_sessions': [clean_session(rs) for rs in recent_sessions],
     }
     with open(json_file, 'w', encoding='utf-8') as f:
         json.dump(json_data, f, indent=2, default=str)

--- a/plugins/alive/scripts/generate-index.py
+++ b/plugins/alive/scripts/generate-index.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
-"""Walnut World Index Generator v3
+"""ALIVE World Index Generator v2
 
-Walks the tree, reads all key.md + companion.md frontmatter, dumps to _index.yaml + _index.json.
-Runs: post-save hook, on-demand via alive:my-context-graph, or manually.
-
-v3 changes:
-- Reads _kernel/now.json (v3 flat) first, falls back to _kernel/_generated/now.json (v2), then now.md (v1)
-- Extracts per-walnut task_counts from enriched now.json (urgent/active/todo/blocked)
-- .walnut/ references migrated to .alive/
+Walks the tree, reads all key.md + context.manifest.yaml frontmatter, dumps to _index.yaml + _index.json.
+Runs: post-save hook, on-demand via alive:map, or manually.
 
 v2 fixes:
 - Correctly identifies walnut names when key.md is inside _core/
@@ -24,6 +19,7 @@ import sys
 import re
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 
 def extract_frontmatter(filepath):
@@ -73,24 +69,48 @@ def extract_frontmatter(filepath):
     return fm
 
 
+def strip_wikilinks(val):
+    """Strip [[brackets]] from a value, returning the inner name."""
+    if isinstance(val, str):
+        return re.sub(r'\[\[([^\]]*)\]\]', r'\1', val).strip()
+    return val
+
+
 def parse_inline_list(val):
-    """Parse [a, b, c] into a list."""
+    """Parse [a, b, c] or [[a]], [[b]] into a clean list.
+    Handles wikilink syntax gracefully — [[name]] becomes name."""
     if not val:
         return []
     val = val.strip()
     if val.startswith('[') and val.endswith(']'):
         val = val[1:-1]
-    return [x.strip().strip('"').strip("'") for x in val.split(',') if x.strip()]
+    items = []
+    for x in val.split(','):
+        x = x.strip().strip('"').strip("'")
+        x = strip_wikilinks(x)
+        if x:
+            items.append(x)
+    return items
 
 
 def extract_wikilinks(val):
-    """Extract [[name]] references from a string or list."""
+    """Extract [[name]] references from a string or list.
+    Also handles bare names and mixed formats."""
     if isinstance(val, list):
         result = []
         for item in val:
-            result.extend(re.findall(r'\[\[([^\]]+)\]\]', str(item)))
+            s = str(item).strip().strip('"').strip("'")
+            # Try extracting wikilink
+            found = re.findall(r'\[\[([^\]]+)\]\]', s)
+            if found:
+                result.extend(found)
+            elif s and not s.startswith('['):
+                # Bare name without brackets
+                result.append(s)
         return result
-    return re.findall(r'\[\[([^\]]+)\]\]', str(val))
+    s = str(val)
+    found = re.findall(r'\[\[([^\]]+)\]\]', s)
+    return found if found else []
 
 
 def parse_people_names(filepath):
@@ -122,7 +142,7 @@ def parse_people_names(filepath):
 
 
 def detect_domain(rel_path):
-    """Determine Walnut domain from relative path."""
+    """Determine ALIVE domain from relative path."""
     parts = rel_path.split(os.sep)
     if not parts:
         return "unknown"
@@ -185,8 +205,8 @@ def main():
 
         # Determine walnut directory — if key.md is inside _core/ or _kernel/, walnut is parent
         walnut_dir = root
-        basename = os.path.basename(root)
-        in_core = basename in ('_core', '_kernel')
+        dir_name = os.path.basename(root)
+        in_core = dir_name in ('_core', '_kernel')
         if in_core:
             walnut_dir = os.path.dirname(root)
 
@@ -238,85 +258,103 @@ def main():
         # Extract people names
         people_names = parse_people_names(keyfile)
 
-        # Read now.json (v3 flat first, v2 generated, then v1 now.md fallback)
+        # Read now.json — v3 first (_kernel/now.json), then v2 fallbacks
         phase = ''
         updated = ''
         next_action = ''
         active_capsule = ''
         task_counts = {}
-        now_json_loaded = False
+        bundle_summary = {}
+        blockers = []
+        recent_sessions = []
+        children_raw = {}
         for candidate in [os.path.join(walnut_dir, '_kernel', 'now.json'),
-                          os.path.join(walnut_dir, '_kernel', '_generated', 'now.json')]:
+                          os.path.join(walnut_dir, '_kernel', '_generated', 'now.json'),
+                          os.path.join(walnut_dir, '_core', '_kernel', '_generated', 'now.json')]:
             if os.path.isfile(candidate):
                 try:
                     with open(candidate, 'r', encoding='utf-8') as nf:
                         now_data = json.load(nf)
                     phase = now_data.get('phase', '')
                     updated = now_data.get('updated', '')
-                    nxt = now_data.get('next')
-                    if isinstance(nxt, dict):
-                        next_action = nxt.get('action', '')
-                    elif isinstance(nxt, str):
-                        next_action = nxt
-                    active_capsule = now_data.get('capsule', now_data.get('outcome', ''))
+                    next_raw = now_data.get('next', '')
+                    if isinstance(next_raw, dict):
+                        next_action = next_raw.get('action', '')
+                    else:
+                        next_action = str(next_raw) if next_raw else ''
+                    active_capsule = now_data.get('bundle', '')
 
-                    # Extract task counts from v3 enriched now.json
-                    tc = {'urgent': 0, 'active': 0, 'todo': 0, 'blocked': 0}
-                    # Unscoped tasks
-                    unscoped = now_data.get('unscoped_tasks', {})
-                    uc = unscoped.get('counts', {})
-                    for k in tc:
-                        tc[k] += uc.get(k, 0)
-                    # Bundle tasks (active + recent tiers)
-                    bundles = now_data.get('bundles', {})
-                    for tier_name in ('active', 'recent'):
-                        tier = bundles.get(tier_name, {})
-                        for bname, bdata in tier.items():
-                            bc = bdata.get('counts', {})
-                            for k in tc:
-                                tc[k] += bc.get(k, 0)
-                    # Only include if there are any non-zero counts
-                    if any(v > 0 for v in tc.values()):
-                        task_counts = tc
+                    # Enrich: task counts
+                    tasks_raw = now_data.get('unscoped_tasks', {})
+                    task_counts = tasks_raw.get('counts', {})
 
-                    now_json_loaded = True
-                except (IOError, json.JSONDecodeError, UnicodeDecodeError):
-                    pass
-                if now_json_loaded:
-                    break
+                    # Enrich: bundle summary
+                    bundles_raw = now_data.get('bundles', {})
+                    bundle_summary = bundles_raw.get('summary', {})
 
-        # v1 fallback: now.md
-        if not now_json_loaded:
-            for candidate in [os.path.join(walnut_dir, '_core', 'now.md'),
-                              os.path.join(walnut_dir, 'now.md')]:
-                if os.path.isfile(candidate):
-                    nfm = extract_frontmatter(candidate)
-                    phase = nfm.get('phase', '')
-                    updated = nfm.get('updated', '')
-                    next_action = nfm.get('next', '')
-                    active_capsule = nfm.get('capsule', nfm.get('outcome', ''))
-                    break
+                    # Enrich: blockers
+                    blockers = now_data.get('blockers', [])
 
-        # Count capsules
+                    # Enrich: recent sessions
+                    recent_sessions = now_data.get('recent_sessions', [])
+
+                    # Enrich: children
+                    children_raw = now_data.get('children', {})
+
+                except (json.JSONDecodeError, IOError):
+                    task_counts = {}
+                    bundle_summary = {}
+                    blockers = []
+                    recent_sessions = []
+                    children_raw = {}
+                break
+
+        # Count bundles (v3: folders with context.manifest.yaml in walnut root)
+        # Also check legacy _capsules/ and _core/_capsules/
         capsule_entries = []
         capsule_count = 0
+        seen_bundles = set()
+
+        # v3: scan walnut root for bundle folders
+        if os.path.isdir(walnut_dir):
+            for item in sorted(os.listdir(walnut_dir)):
+                if item.startswith(('.', '_')):
+                    continue
+                item_path = os.path.join(walnut_dir, item)
+                if not os.path.isdir(item_path):
+                    continue
+                manifest = os.path.join(item_path, 'context.manifest.yaml')
+                if os.path.isfile(manifest):
+                    capsule_count += 1
+                    seen_bundles.add(item)
+                    cfm = extract_frontmatter(manifest)
+                    capsule_entries.append({
+                        'name': item,
+                        'goal': cfm.get('goal', cfm.get('outcome', '')),
+                        'status': cfm.get('status', cfm.get('phase', 'draft')),
+                        'updated': cfm.get('updated', ''),
+                    })
+
+        # v2 fallback: check _capsules/ and _core/_capsules/
         for cap_dir in [os.path.join(walnut_dir, '_core', '_capsules'),
                         os.path.join(walnut_dir, '_capsules')]:
             if os.path.isdir(cap_dir):
                 for item in sorted(os.listdir(cap_dir)):
+                    if item in seen_bundles:
+                        continue
                     cap_path = os.path.join(cap_dir, item)
                     if os.path.isdir(cap_path):
                         capsule_count += 1
-                        comp = os.path.join(cap_path, 'companion.md')
+                        comp = os.path.join(cap_path, 'context.manifest.yaml')
                         if os.path.isfile(comp):
                             cfm = extract_frontmatter(comp)
                             capsule_entries.append({
                                 'name': item,
                                 'goal': cfm.get('goal', ''),
-                                'status': cfm.get('status', 'draft'),
+                                'status': cfm.get('status', cfm.get('phase', 'draft')),
                                 'updated': cfm.get('updated', ''),
                             })
-                break  # Use first capsules dir found
+                break
 
         # Count squirrel sessions
         squirrel_count = 0
@@ -329,6 +367,10 @@ def main():
 
         is_archived = rel_path.startswith('01_Archive')
         total_capsules += capsule_count
+
+        # Session count from recent_sessions
+        session_count = len(recent_sessions)
+        last_session = recent_sessions[0].get('date', '') if recent_sessions else ''
 
         entry = {
             'name': walnut_name,
@@ -350,11 +392,62 @@ def main():
             'tags': tags,
             'people': people_names,
             'parent': parent,
+            # Enriched from now.json
             'task_counts': task_counts,
+            'bundle_summary': bundle_summary,
+            'blockers': blockers,
+            'session_count': session_count,
+            'last_session': last_session,
+            'children': list(children_raw.keys()) if isinstance(children_raw, dict) else [],
         }
 
         target = people_entries if (wtype == 'person' or domain == 'people') else walnut_entries
         target[rel_path] = entry
+
+    # ─── Infer parent-child from filesystem hierarchy ───
+    # For every walnut, find the nearest ancestor walnut by path
+    all_entries = {**walnut_entries, **people_entries}
+    all_paths = sorted(all_entries.keys())
+
+    for rel_path, entry in all_entries.items():
+        if entry.get('parent'):
+            continue  # Already has explicit parent from key.md
+        # Walk up the path to find nearest ancestor walnut
+        parts = rel_path.split(os.sep)
+        for depth in range(len(parts) - 1, 0, -1):
+            candidate = os.sep.join(parts[:depth])
+            if candidate in all_entries and candidate != rel_path:
+                entry['parent'] = all_entries[candidate]['name']
+                break
+
+    # ─── Bidirectional people-walnut links ───
+    # People walnuts often have links: back to ventures/experiments.
+    # Inject those as people references in the target walnuts.
+    walnut_by_name = {e['name']: e for e in walnut_entries.values()}
+    people_by_name = {e['name']: e for e in people_entries.values()}
+
+    for pname, pentry in people_entries.items():
+        person_name = pentry['name']
+        person_links = pentry.get('links', [])
+        for target in person_links:
+            if target in walnut_by_name:
+                # Add this person to the walnut's people list if not already there
+                existing = walnut_by_name[target].get('people', [])
+                if person_name not in existing:
+                    existing.append(person_name)
+                    walnut_by_name[target]['people'] = existing
+
+    # Also: for each walnut's people, if that person has a people walnut with
+    # links, propagate those links as cross-references
+    for wname, wentry in walnut_by_name.items():
+        for person_name in wentry.get('people', []):
+            # Find matching people walnut by name
+            for pname, pentry in people_entries.items():
+                if pentry['name'] == person_name:
+                    for target in pentry.get('links', []):
+                        if target in walnut_by_name and target != wname:
+                            # This person connects these two walnuts
+                            pass  # The graph script handles this via people bridge nodes
 
     # Convert to sorted lists
     walnuts = list(walnut_entries.values())
@@ -366,86 +459,6 @@ def main():
     if os.path.isdir(world_sq_dir):
         world_sq_count = len([f for f in os.listdir(world_sq_dir)
                               if f.endswith('.yaml')])
-
-    # ─── Recent sessions + unsigned stash count ───
-    recent_sessions = []
-    unsigned_with_stash = 0
-    if os.path.isdir(world_sq_dir):
-        sq_files = [f for f in os.listdir(world_sq_dir) if f.endswith('.yaml')]
-        # Sort by modification time, newest first
-        sq_files.sort(
-            key=lambda f: os.path.getmtime(os.path.join(world_sq_dir, f)),
-            reverse=True
-        )
-
-        def extract_sq_field(content, field):
-            """Extract a field value from squirrel YAML via regex."""
-            m = re.search(r'^' + re.escape(field) + r'\s*:\s*(.*)', content, re.MULTILINE)
-            if not m:
-                return ''
-            val = m.group(1).strip()
-            # Remove surrounding quotes
-            if len(val) >= 2 and ((val[0] == '"' and val[-1] == '"') or
-                                   (val[0] == "'" and val[-1] == "'")):
-                val = val[1:-1]
-            return val
-
-        for sq_file in sq_files:
-            sq_path = os.path.join(world_sq_dir, sq_file)
-            try:
-                with open(sq_path, 'r', encoding='utf-8') as sf:
-                    sq_content = sf.read()
-            except (IOError, UnicodeDecodeError):
-                continue
-
-            saves_str = extract_sq_field(sq_content, 'saves')
-            saves_val = 0
-            try:
-                saves_val = int(saves_str)
-            except (ValueError, TypeError):
-                pass
-
-            # Check for unsigned with non-empty stash
-            has_empty_stash = bool(re.search(r'^stash\s*:\s*\[\s*\]\s*$', sq_content, re.MULTILINE))
-            has_stash_key = bool(re.search(r'^stash\s*:', sq_content, re.MULTILINE))
-            if saves_val == 0 and has_stash_key and not has_empty_stash:
-                # Check stash actually has items (next line starts with "  - ")
-                stash_m = re.search(r'^stash\s*:.*\n(\s+-\s)', sq_content, re.MULTILINE)
-                if stash_m:
-                    unsigned_with_stash += 1
-
-            # Collect recent sessions (top 10 by mtime)
-            if len(recent_sessions) < 10:
-                session_id = extract_sq_field(sq_content, 'session_id')
-                walnut = extract_sq_field(sq_content, 'walnut')
-                started = extract_sq_field(sq_content, 'started')
-                recovery = extract_sq_field(sq_content, 'recovery_state')
-                bundle = extract_sq_field(sq_content, 'bundle')
-                tags_raw = extract_sq_field(sq_content, 'tags')
-
-                # Extract date from started (YYYY-MM-DD)
-                date = ''
-                if started:
-                    date_m = re.match(r'(\d{4}-\d{2}-\d{2})', started)
-                    if date_m:
-                        date = date_m.group(1)
-
-                # Parse inline tags [a, b, c]
-                tags_list = parse_inline_list(tags_raw)
-
-                entry = {
-                    'squirrel': session_id[:8] if session_id else sq_file[:8],
-                    'walnut': walnut if walnut and walnut != 'null' else '',
-                    'date': date,
-                    'saves': saves_val,
-                    'summary': recovery,
-                }
-                if bundle:
-                    entry['bundle'] = bundle
-                if tags_list:
-                    entry['tags'] = tags_list
-
-                recent_sessions.append(entry)
 
     # Inputs count
     inputs_dir = os.path.join(world_root, '03_Inbox')
@@ -462,7 +475,7 @@ def main():
 
     # ─── Write YAML index ───
     lines = [
-        '# Walnut World Index — GENERATED, DO NOT HAND-EDIT',
+        '# ALIVE World Index — GENERATED, DO NOT HAND-EDIT',
         '# Regenerated by .alive/scripts/generate-index.py',
         f'generated: "{timestamp}"',
         f'walnut_count: {len(walnuts)}',
@@ -510,13 +523,6 @@ def main():
             lines.append(f'    active_capsule: {w["active_capsule"]}')
         if w['next']:
             lines.append(f'    next: {yaml_escape(w["next"])}')
-        if w.get('task_counts'):
-            tc = w['task_counts']
-            lines.append(f'    task_counts:')
-            lines.append(f'      urgent: {tc.get("urgent", 0)}')
-            lines.append(f'      active: {tc.get("active", 0)}')
-            lines.append(f'      todo: {tc.get("todo", 0)}')
-            lines.append(f'      blocked: {tc.get("blocked", 0)}')
         if w['capsules']:
             lines.append(f'    capsules:')
             for c in w['capsules']:
@@ -535,28 +541,6 @@ def main():
         lines.append(f'    path: {yaml_escape(p["path"])}')
         lines.append(f'    updated: {yaml_escape(p["updated"] or "unknown")}')
 
-    lines.append('')
-    lines.append('recent_sessions:')
-    if recent_sessions:
-        for rs in recent_sessions:
-            lines.append(f'  - squirrel: {yaml_escape(rs["squirrel"])}')
-            if rs.get('walnut'):
-                lines.append(f'    walnut: {yaml_escape(rs["walnut"])}')
-            if rs.get('date'):
-                lines.append(f'    date: {yaml_escape(rs["date"])}')
-            if rs.get('bundle'):
-                lines.append(f'    bundle: {yaml_escape(rs["bundle"])}')
-            lines.append(f'    saves: {rs["saves"]}')
-            if rs.get('summary'):
-                lines.append(f'    summary: {yaml_escape(rs["summary"])}')
-            if rs.get('tags'):
-                lines.append(f'    tags: {yaml_list(rs["tags"])}')
-    else:
-        lines.append('  # no recent sessions found')
-
-    lines.append('')
-    lines.append(f'unsigned_with_stash: {unsigned_with_stash}')
-
     output = '\n'.join(lines) + '\n'
 
     os.makedirs(alive_dir, exist_ok=True)
@@ -565,20 +549,9 @@ def main():
 
     # ─── Write JSON for graph consumption ───
     # Strip empty values for cleaner JSON
-    def clean(entry, keep_zero=None):
-        keep_zero = keep_zero or set()
+    def clean(entry):
         return {k: v for k, v in entry.items()
-                if v or v == 0 and k in keep_zero
-                or (v != '' and v != [] and v is not None and v is not False)}
-
-    def clean_walnut(entry):
-        return {k: v for k, v in entry.items()
-                if v and v != [] and v != 0 and v is not False}
-
-    def clean_session(entry):
-        """Clean session entry but preserve saves: 0 since it's meaningful."""
-        return {k: v for k, v in entry.items()
-                if k == 'saves' or (v and v != [] and v is not False)}
+                if v and v != [] and v != 0 and v != False}
 
     json_data = {
         'generated': timestamp,
@@ -588,11 +561,9 @@ def main():
             'capsules': total_capsules,
             'sessions': world_sq_count,
             'inputs': input_count,
-            'unsigned_with_stash': unsigned_with_stash,
         },
-        'walnuts': [clean_walnut(w) for w in walnuts],
-        'people': [clean_walnut(p) for p in people],
-        'recent_sessions': [clean_session(rs) for rs in recent_sessions],
+        'walnuts': [clean(w) for w in walnuts],
+        'people': [clean(p) for p in people],
     }
     with open(json_file, 'w', encoding='utf-8') as f:
         json.dump(json_data, f, indent=2, default=str)


### PR DESCRIPTION
## Summary

- **Index script (generate-index.py)** was v2 — looking for `_core/` instead of `_kernel/`, reading `now.json` as markdown, scanning for `_capsules/` instead of bundles. Every user got broken graph output with 0 bundles detected and ghost `_kernel` nodes.
- **Graph script (generate-graph.py)** used circle packing, which is wrong for a network with hierarchy. Replaced with force-directed + domain cluster gravity, based on Obsidian graph view research.

## What changed

### Index fixes
- Recognize `_kernel/` as walnut parent dir (v3 structure)
- Read `now.json` as JSON (was parsing as markdown frontmatter)
- Detect bundles via `context.manifest.yaml` (was scanning `_capsules/`)
- Infer parent-child from filesystem hierarchy (nested walnuts auto-link)
- Bidirectional people-walnut links (person walnut `links:` → walnut `people:`)
- Strip `[[wikilinks]]` on read — handles YAML parse issue at consumer level
- Enrich with `now.json`: task counts, bundle summaries, blockers, session data

### Graph rebuild
- Force-directed with domain cluster gravity (Life/Ventures/Experiments/People/Archive)
- Health indicators (green/amber/red border based on rhythm vs last update)
- Detail panel on click (goal, next action, tasks, bundles, people, connections)
- Neighborhood highlighting on hover (dim everything else)
- Task urgency dots + blocker flags directly on nodes
- Semantic zoom, search, dark mode, people toggle, archive toggle

## Test plan

- [ ] Run `python3 .alive/scripts/generate-index.py` — verify walnuts detected, bundles > 0
- [ ] Run `python3 .alive/scripts/generate-graph.py` — verify HTML generated
- [ ] Open graph — verify domain clusters, click nodes for detail panel
- [ ] Test with v2 world (has `_core/`, `_capsules/`) — verify backward compat
- [ ] Test `[[wikilink]]` in `linked_bundles:` field — verify no YAML parse error
- [ ] Test on Windows with `py -3` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)