### PR TITLE
fix: post-write hook debounce break outside loop

### DIFF
--- a/plugins/alive/hooks/scripts/alive-post-write.sh
+++ b/plugins/alive/hooks/scripts/alive-post-write.sh
@@ -50,7 +50,7 @@ case "$FILE_PATH" in
             MARKER_MTIME=$(stat -f %m "$MARKER" 2>/dev/null || echo "0")
           fi
           AGE=$(( $(date +%s) - MARKER_MTIME ))
-          [ "$AGE" -lt 300 ] && break
+          [ "$AGE" -lt 300 ] && exit 0
         fi
         touch "$MARKER"
         # Background -- don't block the session


### PR DESCRIPTION
## Summary
- The project.py debounce guard in `alive-post-write.sh` (line 53) used `break` to early-exit when the walnut was already projected within the last 5 minutes
- `break` is only valid inside `for`/`while`/`until` loops — inside a `case` statement, bash emits `"break: only meaningful in a for, while, or until loop"` to stderr and returns non-zero, which can surface as a hook failure in Claude Code
- Changed to `exit 0`, matching the identical debounce pattern for `generate-index.py` on line 80

## Test plan
- [ ] Trigger a `log.md` write twice within 5 minutes for the same walnut — second invocation should exit cleanly with no stderr
- [ ] Confirm `project.py` still runs on the first write (marker file created)
- [ ] Verify no "break: only meaningful" errors in hook output

🤖 Generated with [Claude Code](https://claude.com/claude-code)