### PR TITLE
feat: conversation topic in statusline

### DIFF
--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -110,6 +110,7 @@ session_id: $SESSION_ID
 runtime_id: squirrel.core@1.0
 engine: $HOOK_MODEL
 walnut: null
+topic: null
 started: $TIMESTAMP
 ended: null
 saves: 0

--- a/plugins/alive/rules/squirrels.md
+++ b/plugins/alive/rules/squirrels.md
@@ -463,6 +463,7 @@ runtime_id: squirrel.core@3.0
 engine: claude-opus-4-6
 squirrel_name: Toby
 walnut: nova-station
+topic: "nova-station/shielding-review"
 started: 2026-03-28T12:00:00
 ended: 2026-03-28T14:00:00
 signed: true
@@ -490,6 +491,24 @@ working:
 Entries accumulate. They're tiny and scannable. Don't archive them.
 
 `squirrel_name` records which persona was active. `recovery_state` is a human-readable sentence describing exactly where work stopped — the first thing the next session reads if this entry is unsigned.
+
+### Conversation Topic
+
+`topic:` is the conversation name shown in the statusline. Laconic — two or three words max. The squirrel maintains it by writing to the squirrel YAML via Bash (`sed`).
+
+**When to set it:**
+- **Walnut loaded:** set to the walnut name (e.g., `nova-station`)
+- **Bundle focused:** set to `walnut/bundle` (e.g., `nova-station/shielding-review`)
+- **Topic shifts:** if the conversation moves to a different walnut or substantially different work, update it
+- **No walnut:** set a short descriptor (e.g., `roadmap`, `morning review`, `debugging hooks`)
+
+**How to write it:**
+
+```bash
+sed -i '' "s/^topic:.*/topic: nova-station\/shielding-review/" "$WORLD_ROOT/.alive/_squirrels/$SESSION_ID.yaml"
+```
+
+Keep it short. The statusline has limited space. `alivecomputer/hermes-plugin` is fine. `working on the hermes plugin integration for the alive computer product` is not.
 
 ---
 

--- a/plugins/alive/statusline/alive-statusline.sh
+++ b/plugins/alive/statusline/alive-statusline.sh
@@ -152,9 +152,14 @@ fi
 
 # ── WORKING STATUSLINE ──
 
-# Detect active walnut from squirrel YAML
+# Detect conversation topic and active walnut from squirrel YAML
 ACTIVE_WALNUT=""
+TOPIC=""
 if [ -f "$ENTRY" ]; then
+  TOPIC=$(grep '^topic:' "$ENTRY" 2>/dev/null | sed 's/topic: *//' | sed 's/^"//;s/"$//')
+  if [ "$TOPIC" = "null" ] || [ -z "$TOPIC" ]; then
+    TOPIC=""
+  fi
   # Check walnut: field first (set by save), then repo_context: (set by repo detection)
   ACTIVE_WALNUT=$(grep '^walnut:' "$ENTRY" 2>/dev/null | sed 's/walnut: *//' | tr -d ' ')
   if [ "$ACTIVE_WALNUT" = "null" ] || [ -z "$ACTIVE_WALNUT" ]; then
@@ -162,8 +167,11 @@ if [ -f "$ENTRY" ]; then
   fi
 fi
 
+# Topic takes priority over raw walnut name
 WALNUT_DISPLAY=""
-if [ -n "$ACTIVE_WALNUT" ]; then
+if [ -n "$TOPIC" ]; then
+  WALNUT_DISPLAY=" ${DIM}|${RESET} ${GREEN}${TOPIC}${RESET}"
+elif [ -n "$ACTIVE_WALNUT" ]; then
   WALNUT_DISPLAY=" ${DIM}|${RESET} ${GREEN}${ACTIVE_WALNUT}${RESET}"
 fi
 


### PR DESCRIPTION
## Summary
- Adds `topic:` field to squirrel YAML (initialized as `null` by session-start hook)
- Statusline reads `topic:` and displays it as the conversation name, falling back to `walnut:` if unset
- Squirrel rule convention: agent maintains the topic — walnut name on load, `walnut/bundle` when focused, short descriptor for freestyle sessions

Laconic by convention. `alivecomputer/hermes-plugin` not `working on the hermes plugin integration`.

## Test plan
- [ ] New session creates YAML with `topic: null` — statusline shows walnut name as before
- [ ] Agent sets topic via `sed` — statusline updates on next render
- [ ] Topic with quotes/slashes parses correctly
- [ ] Falls back to walnut name when topic is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)