### PR TITLE
chore: GitHub Flow + run release tests in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 
 ## Verification
 
+- [ ] `python3 -m unittest discover -s tests/release` passes
 - [ ] Tested against a real walnut (not just a scaffold)
 - [ ] Backward compatible — existing walnuts still load correctly
 - [ ] Templates match any schema changes

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,36 @@
+name: Release Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
+      - name: Run release tests
+        run: python3 -m unittest discover -s tests/release -v
+
+  hermes-offline:
+    # Offline installer tests. Pytest is an extra dep; this job must not
+    # fail the repository if the suite cannot run.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pytest
+        run: python3 -m pip install --user pytest
+
+      - name: Run offline Hermes installer tests
+        run: python3 -m pytest hermes/tests -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,26 @@ plugins/alive/
   CLAUDE.md       the core runtime definition
 ```
 
+## How we ship
+
+Public [`alive`](https://github.com/alivecontext/alive) `main` is the only product trunk. Users install from tags on this repo.
+
+All shippable work is a branch + PR into `main`. Name branches `fix/…` or `feat/…`.
+
+- CI must pass. Release tests are required, not optional:
+
+  ```bash
+  python3 -m unittest discover -s tests/release
+  ```
+
+  That suite needs `zsh` for the env-file quoting checks.
+
+- Close the GitHub issue in the same PR that ships the fix. Do not leave "fixed in 3.2.x" issues open.
+
+`alivecontext/alive-staging` is private scratch for unreleased/untested work (surface UI, license experiments, papers). It is not the product trunk. Do not land reliability fixes only there. Promote only named cherry-picks, never a bulk 78-commit dump.
+
+Claude Code is the only supported runtime in this release. Do not claim Hermes, MCP, or Codex as shipped.
+
 ## Making Changes
 
 ### Skills
@@ -52,7 +72,7 @@ Templates in `plugins/alive/templates/` define the schema for system files. The 
 
 - Keep PRs focused on a single change
 - Describe what changed and why
-- Reference any related issues
+- Close the related GitHub issue from the same PR (`Closes #N`)
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ ALIVE is open source. As you use it, the plugin will surface a small invitation 
 
 ## Contributing
 
+`main` on this repo is the product trunk. Open a `fix/…` or `feat/…` PR; CI and release tests must pass. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 [Open an issue](https://github.com/alivecontext/alive/issues) · [Discussions](https://github.com/alivecontext/alive/discussions) · [Contributing guide](CONTRIBUTING.md)
 
 ---

--- a/plugins/alive/statusline/alive-statusline.sh
+++ b/plugins/alive/statusline/alive-statusline.sh
@@ -154,7 +154,8 @@ if [ ! -f "$ENTRY" ]; then
   TRANSCRIPT_AGE=999
   if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     NOW=$(date +%s)
-    MTIME=$(stat -f %m "$TRANSCRIPT_PATH" 2>/dev/null || stat -c %Y "$TRANSCRIPT_PATH" 2>/dev/null || echo 0)
+    # GNU `stat -c` first: BSD `stat -f` on GNU dumps filesystem info to stdout.
+    MTIME=$(stat -c %Y "$TRANSCRIPT_PATH" 2>/dev/null || stat -f %m "$TRANSCRIPT_PATH" 2>/dev/null || echo 0)
     if [[ "$MTIME" =~ ^[0-9]+$ ]]; then
       TRANSCRIPT_AGE=$((NOW - MTIME))
     fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Component:** other
**Breaking:** no

## What changed

- Document GitHub Flow in `CONTRIBUTING.md`: public `alive` `main` is the product trunk; ship via `fix/…` or `feat/…` PRs; close the GitHub issue in the same PR.
- Point at that flow from the README Contributing section.
- Require the release-test command on the PR template.
- Add `.github/workflows/release-tests.yml` so PRs and pushes to `main` run `python3 -m unittest discover -s tests/release` (installs `zsh` for the env-file quoting checks).
- Keep `validate-plugin.yml` and `validate-repository.yml` as they are (structure/policy only).
- Optional `hermes-offline` job (`continue-on-error`) for the pytest-only Hermes installer suite.
- One-line statusline `stat` order swap (`stat -c` before `stat -f`) so the existing grace-window test can pass on GNU/Linux CI. No walnut contract or hook changes.

## Why

Structure/policy CI was not running the release unittest suite, so those gates were optional in practice. Staging is scratch, not a second trunk.

## Verification

- [x] `python3 scripts/validate-repository.py` passes
- [x] `python3 -m pytest hermes/tests -q` — 20 passed (optional job)
- [x] `python3 -m unittest discover -s tests/release` — 32 passed
- [x] GitHub Actions: **release-tests**, **hermes-offline**, **Validate Plugin Structure**, **Validate Repository Policy** all green
- [x] No live-network tests added

`claude-review` / `pii-review` fail because the Claude Code action rejects the `cursor` bot (`allowed_bots`). Those checks are advisory and not required. Not caused by this diff.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77011bf0-c695-4da7-8434-2967857f5c35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77011bf0-c695-4da7-8434-2967857f5c35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

