### PR TITLE
fix(windows): SessionStart world resolve, statusline JSON, and file locks (#67)

### DIFF
--- a/plugins/alive/hooks/scripts/alive-common.sh
+++ b/plugins/alive/hooks/scripts/alive-common.sh
@@ -4,10 +4,32 @@
 # Cross-platform: python3 (Mac/Linux) with node fallback (Windows/all).
 
 # -- Platform detection --
+# SessionStart invokes `bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/alive-session-*.sh`
+# (hooks.json). Git Bash sets OSTYPE itself at startup (typically `msys`;
+# MACHTYPE may still say cygwin) and MSYSTEM=MINGW64. ALIVE_PLATFORM is
+# computed here when the hook sources this file -- Claude does not pass
+# the flag in. If detection misses, the 3.2.1 drive-letter convert never
+# runs and SessionStart reports NO WORLD FOUND (alive#67).
+# Exact `OSTYPE == msys` misses `msys2` and relies on a single automatic
+# variable; also honour prefixes, MSYSTEM, and MACHTYPE.
+_alive_is_windows_shell() {
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win32*|mingw*) return 0 ;;
+  esac
+  case "${MSYSTEM:-}" in
+    MINGW*|MSYS*|UCRT*|CLANG*) return 0 ;;
+  esac
+  case "${MACHTYPE:-}" in
+    *mingw*|*msys*|*cygwin*) return 0 ;;
+  esac
+  return 1
+}
+
 ALIVE_PLATFORM="unix"
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+if _alive_is_windows_shell; then
   ALIVE_PLATFORM="windows"
 fi
+export ALIVE_PLATFORM
 
 # Append a shell-safe assignment to Claude Code's environment handoff file.
 # The file is evaluated by the user's shell, so raw paths containing spaces,
@@ -40,6 +62,28 @@ elif command -v py &>/dev/null && py -3 -c "" &>/dev/null 2>&1; then
 elif command -v node &>/dev/null; then
   ALIVE_JSON_RT="node"
 fi
+
+# JSON-encode a string (including the surrounding quotes).
+# Uses single-quoted python3 -c / node -e so nested double quotes cannot
+# empty the expansion on Git Bash / MINGW64. The SessionStart statusline
+# injector used a double-quoted python3 -c '...decode("utf-8"...)' one-liner
+# that expands to nothing on Windows and writes `"command":` with no value
+# (malformed .claude/settings.json; alive#67 follow-on).
+alive_json_encode_string() {
+  local _alive_json_in="$1"
+  if [ "$ALIVE_JSON_RT" = "python3" ]; then
+    printf '%s' "$_alive_json_in" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.buffer.read().decode("utf-8","replace")))'
+    return $?
+  fi
+  if [ "$ALIVE_JSON_RT" = "node" ]; then
+    printf '%s' "$_alive_json_in" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.stringify(d)))'
+    return $?
+  fi
+  local escaped
+  escaped="${_alive_json_in//\\/\\\\}"
+  escaped="${escaped//\"/\\\"}"
+  printf '"%s"\n' "$escaped"
+}
 
 # -- JSON parsing helpers --
 # All JSON parsing goes through python3 or node. Never sed/regex.
@@ -548,6 +592,9 @@ lexical_normalize_path() {
   # Python resolver persists paths such as ``C:\Users\Ada\alive``. Convert
   # that one drive-letter shape to the MSYS mount form before the POSIX
   # absolute-path check so both resolver halves accept the same config value.
+  # Gated on ALIVE_PLATFORM, which SessionStart sets by sourcing this file
+  # (hooks.json runs `bash .../alive-session-new.sh`; Claude does not pass
+  # the flag). Detection is at the top of this file.
   if [ "$ALIVE_PLATFORM" = "windows" ] \
     && [[ "${p:0:1}" == [A-Za-z] ]] \
     && [ "${p:1:1}" = ":" ] \

--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -218,11 +218,13 @@ fix_statusline_in_settings() {
   if [ ! -f "$settings_file" ]; then
     # Only create project-level settings, not user-level
     if [ "$settings_file" = "$WORLD_ROOT/.claude/settings.json" ]; then
+      local cmd_json
+      cmd_json="$(alive_json_encode_string "$STATUSLINE_CMD")"
       cat > "$settings_file" << SETTINGSEOF
 {
   "statusLine": {
     "type": "command",
-    "command": $( if [ "$ALIVE_JSON_RT" = "python3" ]; then printf '%s' "$STATUSLINE_CMD" | python3 -c "import sys,json; print(json.dumps(sys.stdin.buffer.read().decode("utf-8","replace")))" 2>/dev/null; elif [ "$ALIVE_JSON_RT" = "node" ]; then printf '%s' "$STATUSLINE_CMD" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.stringify(d)))" 2>/dev/null; else echo "\"$STATUSLINE_CMD\""; fi )
+    "command": $cmd_json
   }
 }
 SETTINGSEOF
@@ -230,49 +232,48 @@ SETTINGSEOF
     return
   fi
 
-  # settings.json exists -- ensure statusLine uses correct .alive/ path with quoting
+  # settings.json exists -- ensure statusLine uses correct .alive/ path with quoting.
+  # python3 -c / node -e are single-quoted so nested quotes stay intact on Git Bash.
   if [ "$ALIVE_JSON_RT" = "python3" ]; then
-    ALIVE_SETTINGS_FILE="$settings_file" ALIVE_WORLD_ROOT="$WORLD_ROOT" python3 -c "
+    ALIVE_SETTINGS_FILE="$settings_file" ALIVE_WORLD_ROOT="$WORLD_ROOT" python3 -c '
 import json, os, sys
-sf = os.environ['ALIVE_SETTINGS_FILE']
-wr = os.environ['ALIVE_WORLD_ROOT']
-# Quoted command handles paths with spaces (iCloud, etc.)
-expected_cmd = 'bash \"' + wr + '/.alive/statusline.sh\"'
+sf = os.environ["ALIVE_SETTINGS_FILE"]
+wr = os.environ["ALIVE_WORLD_ROOT"]
+expected_cmd = "bash \"" + wr + "/.alive/statusline.sh\""
 try:
     with open(sf) as f:
         data = json.load(f)
 except (json.JSONDecodeError, ValueError):
-    print('ALIVE: settings.json is malformed, cannot inject statusLine', file=sys.stderr)
+    print("ALIVE: settings.json is malformed, cannot inject statusLine", file=sys.stderr)
     sys.exit(0)
-current = data.get('statusLine', {}).get('command', '')
-# Fix if: missing, wrong path, stale .walnut/ reference, or unquoted path with spaces
+current = data.get("statusLine", {}).get("command", "")
 needs_fix = (
     current != expected_cmd
     and (
         not current
-        or '.walnut/' in current
-        or ('.alive/statusline.sh' in current and 'bash ' not in current and ' ' in wr)
+        or ".walnut/" in current
+        or (".alive/statusline.sh" in current and "bash " not in current and " " in wr)
     )
 )
 if needs_fix:
-    data['statusLine'] = {'type': 'command', 'command': expected_cmd}
-    with open(sf, 'w') as f:
+    data["statusLine"] = {"type": "command", "command": expected_cmd}
+    with open(sf, "w") as f:
         json.dump(data, f, indent=2)
-        f.write('\n')
-    print('ALIVE: fixed statusLine in ' + sf, file=sys.stderr)
-" 2>/dev/null || true
+        f.write("\n")
+    print("ALIVE: fixed statusLine in " + sf, file=sys.stderr)
+' 2>/dev/null || true
   elif [ "$ALIVE_JSON_RT" = "node" ]; then
-    ALIVE_SETTINGS_FILE="$settings_file" ALIVE_WORLD_ROOT="$WORLD_ROOT" node -e "
-const fs=require('fs');
+    ALIVE_SETTINGS_FILE="$settings_file" ALIVE_WORLD_ROOT="$WORLD_ROOT" node -e '
+const fs=require("fs");
 const sf=process.env.ALIVE_SETTINGS_FILE;
 const wr=process.env.ALIVE_WORLD_ROOT;
-const expected='bash \"'+wr+'/.alive/statusline.sh\"';
+const expected="bash \""+wr+"/.alive/statusline.sh\"";
 let data;
-try{data=JSON.parse(fs.readFileSync(sf,'utf8'))}catch(e){process.exit(0)}
-const current=(data.statusLine||{}).command||'';
-const needsFix=current!==expected&&(!current||current.includes('.walnut/')||(current.includes('.alive/statusline.sh')&&!current.includes('bash ')&&wr.includes(' ')));
-if(needsFix){data.statusLine={type:'command',command:expected};fs.writeFileSync(sf,JSON.stringify(data,null,2)+'\n');console.error('ALIVE: fixed statusLine in '+sf)}
-" 2>/dev/null || true
+try{data=JSON.parse(fs.readFileSync(sf,"utf8"))}catch(e){process.exit(0)}
+const current=(data.statusLine||{}).command||"";
+const needsFix=current!==expected&&(!current||current.includes(".walnut/")||(current.includes(".alive/statusline.sh")&&!current.includes("bash ")&&wr.includes(" ")));
+if(needsFix){data.statusLine={type:"command",command:expected};fs.writeFileSync(sf,JSON.stringify(data,null,2)+"\n");console.error("ALIVE: fixed statusLine in "+sf)}
+' 2>/dev/null || true
   fi
 }
 

--- a/plugins/alive/hooks/scripts/alive-session-resume.sh
+++ b/plugins/alive/hooks/scripts/alive-session-resume.sh
@@ -72,44 +72,45 @@ SETTINGS_DIR="$WORLD_ROOT/.claude"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 mkdir -p "$SETTINGS_DIR"
 if [ ! -f "$SETTINGS_FILE" ]; then
+  cmd_json="$(alive_json_encode_string "$WORLD_ROOT/.alive/statusline.sh")"
   cat > "$SETTINGS_FILE" << SETTINGSEOF
 {
   "statusLine": {
     "type": "command",
-    "command": "$WORLD_ROOT/.alive/statusline.sh"
+    "command": $cmd_json
   }
 }
 SETTINGSEOF
 else
   if [ "$ALIVE_JSON_RT" = "python3" ]; then
-    ALIVE_SETTINGS_FILE="$SETTINGS_FILE" ALIVE_WORLD_ROOT="$WORLD_ROOT" python3 -c "
+    ALIVE_SETTINGS_FILE="$SETTINGS_FILE" ALIVE_WORLD_ROOT="$WORLD_ROOT" python3 -c '
 import json, os, sys
-sf = os.environ['ALIVE_SETTINGS_FILE']
-wr = os.environ['ALIVE_WORLD_ROOT']
-expected = wr + '/.alive/statusline.sh'
+sf = os.environ["ALIVE_SETTINGS_FILE"]
+wr = os.environ["ALIVE_WORLD_ROOT"]
+expected = wr + "/.alive/statusline.sh"
 try:
     with open(sf) as f:
         data = json.load(f)
 except (json.JSONDecodeError, ValueError):
     sys.exit(0)
-current = data.get('statusLine', {}).get('command', '')
+current = data.get("statusLine", {}).get("command", "")
 if current != expected:
-    data['statusLine'] = {'type': 'command', 'command': expected}
-    with open(sf, 'w') as f:
+    data["statusLine"] = {"type": "command", "command": expected}
+    with open(sf, "w") as f:
         json.dump(data, f, indent=2)
-        f.write('\n')
-" 2>/dev/null || true
+        f.write("\n")
+' 2>/dev/null || true
   elif [ "$ALIVE_JSON_RT" = "node" ]; then
-    ALIVE_SETTINGS_FILE="$SETTINGS_FILE" ALIVE_WORLD_ROOT="$WORLD_ROOT" node -e "
-const fs=require('fs');
+    ALIVE_SETTINGS_FILE="$SETTINGS_FILE" ALIVE_WORLD_ROOT="$WORLD_ROOT" node -e '
+const fs=require("fs");
 const sf=process.env.ALIVE_SETTINGS_FILE;
 const wr=process.env.ALIVE_WORLD_ROOT;
-const expected=wr+'/.alive/statusline.sh';
+const expected=wr+"/.alive/statusline.sh";
 let data;
-try{data=JSON.parse(fs.readFileSync(sf,'utf8'))}catch(e){process.exit(0)}
-const current=(data.statusLine||{}).command||'';
-if(current!==expected){data.statusLine={type:'command',command:expected};fs.writeFileSync(sf,JSON.stringify(data,null,2)+'\n')}
-" 2>/dev/null || true
+try{data=JSON.parse(fs.readFileSync(sf,"utf8"))}catch(e){process.exit(0)}
+const current=(data.statusLine||{}).command||"";
+if(current!==expected){data.statusLine={type:"command",command:expected};fs.writeFileSync(sf,JSON.stringify(data,null,2)+"\n")}
+' 2>/dev/null || true
   fi
 fi
 

--- a/plugins/alive/scripts/_common.py
+++ b/plugins/alive/scripts/_common.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 import contextlib
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -51,6 +50,19 @@ import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
+
+# Native Windows CPython has no fcntl; MSYS/Cygwin Python does. Prefer
+# fcntl when present, msvcrt.locking otherwise. Never silently no-op:
+# a missing backend must fail loud (alive#67).
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:
+    _msvcrt = None
 
 # ---------------------------------------------------------------------------
 # Vendored package bootstrap
@@ -789,7 +801,7 @@ def resolve_session_id(override=None):
 
 
 # ---------------------------------------------------------------------------
-# Advisory file locking (fcntl.flock context manager + ownership token)
+# Advisory file locking (fcntl.flock on POSIX, msvcrt.locking on Windows)
 # ---------------------------------------------------------------------------
 
 #: Default total wait budget (seconds) and per-retry sleep for flock_file.
@@ -798,6 +810,92 @@ def resolve_session_id(override=None):
 #: same backpressure characteristics on contended walnuts.
 _FLOCK_DEFAULT_TIMEOUT_SECONDS = 5.0
 _FLOCK_DEFAULT_RETRY_INTERVAL = 0.1
+
+#: Byte length of the msvcrt.locking region. 1 byte from offset 0 is
+#: enough to serialize writers; the lockfile is a sentinel, not payload.
+_MSVCRT_LOCK_LENGTH = 1
+
+_MSVCRT_BLOCKED_ERRNOS = {
+    errno.EACCES,
+    errno.EAGAIN,
+    getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+    getattr(errno, "EDEADLOCK", None),
+    getattr(errno, "EDEADLK", None),
+}
+_MSVCRT_BLOCKED_ERRNOS.discard(None)
+
+
+def _msvcrt_prepare_lock_region(fd):
+    """Seek to 0 and ensure at least 1 byte so ``msvcrt.locking`` has a region."""
+    os.lseek(fd, 0, os.SEEK_SET)
+    try:
+        size = os.fstat(fd).st_size
+    except OSError:
+        size = 0
+    if size < 1:
+        os.write(fd, b"\0")
+        os.lseek(fd, 0, os.SEEK_SET)
+
+
+def msvcrt_lock_exclusive_nb(fd, msvcrt_mod=None):
+    """Non-blocking exclusive lock via ``msvcrt.locking``.
+
+    Raises ``BlockingIOError`` when another holder owns the region so
+    the ``flock_file`` retry loop can treat POSIX and Windows the same.
+    *msvcrt_mod* is a test seam (Linux CI has no msvcrt).
+    """
+    mod = _msvcrt if msvcrt_mod is None else msvcrt_mod
+    if mod is None:
+        raise RuntimeError("msvcrt is not available")
+    _msvcrt_prepare_lock_region(fd)
+    try:
+        mod.locking(fd, mod.LK_NBLCK, _MSVCRT_LOCK_LENGTH)
+    except OSError as exc:
+        if getattr(exc, "errno", None) in _MSVCRT_BLOCKED_ERRNOS:
+            raise BlockingIOError from exc
+        raise
+
+
+def msvcrt_unlock(fd, msvcrt_mod=None):
+    """Release the ``msvcrt.locking`` region acquired by :func:`msvcrt_lock_exclusive_nb`."""
+    mod = _msvcrt if msvcrt_mod is None else msvcrt_mod
+    if mod is None:
+        raise RuntimeError("msvcrt is not available")
+    os.lseek(fd, 0, os.SEEK_SET)
+    mod.locking(fd, mod.LK_UNLCK, _MSVCRT_LOCK_LENGTH)
+
+
+def _lock_exclusive_nb(fd):
+    """Acquire a non-blocking exclusive lock on *fd*.
+
+    fcntl.flock on POSIX (including Cygwin/MSYS Python); msvcrt.locking
+    on native Windows. Raises ``BlockingIOError`` on contention. Raises
+    ``RuntimeError`` if neither backend exists -- never a silent no-op.
+    """
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        return
+    if _msvcrt is not None:
+        msvcrt_lock_exclusive_nb(fd, _msvcrt)
+        return
+    raise RuntimeError(
+        "file locking requires fcntl (POSIX) or msvcrt (Windows); "
+        "neither module is available"
+    )
+
+
+def _unlock_fd(fd):
+    """Release the exclusive lock on *fd* acquired by :func:`_lock_exclusive_nb`."""
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_UN)
+        return
+    if _msvcrt is not None:
+        msvcrt_unlock(fd, _msvcrt)
+        return
+    raise RuntimeError(
+        "file locking requires fcntl (POSIX) or msvcrt (Windows); "
+        "neither module is available"
+    )
 
 
 class FlockTimeoutError(OSError):
@@ -865,11 +963,12 @@ def flock_file(
     :class:`LockGuard` token.
 
     The lockfile is created (mode ``0o644``) if missing. The lock is
-    acquired with ``LOCK_EX | LOCK_NB`` in a bounded retry loop so a
-    blocked writer never stalls longer than ``timeout_seconds``; on
-    timeout :class:`FlockTimeoutError` is raised. The fd carries the
-    ``O_CLOEXEC`` flag where supported so child processes never inherit
-    the lock holder by accident.
+    acquired non-blocking (fcntl.flock LOCK_EX|LOCK_NB on POSIX,
+    msvcrt.locking LK_NBLCK on native Windows) in a bounded retry loop
+    so a blocked writer never stalls longer than ``timeout_seconds``; on
+    timeout :class:`FlockTimeoutError` is raised. Neither backend is a
+    silent no-op. The fd carries the ``O_CLOEXEC`` flag where supported
+    so child processes never inherit the lock holder by accident.
 
     Parent directories are created as needed. The yielded guard's
     ``path`` is the absolute (`os.path.abspath`) form of *lock_path* so
@@ -894,7 +993,7 @@ def flock_file(
         deadline = time.monotonic() + float(timeout_seconds)
         while True:
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _lock_exclusive_nb(fd)
                 break
             except BlockingIOError:
                 pass
@@ -913,7 +1012,7 @@ def flock_file(
             yield guard
         finally:
             try:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                _unlock_fd(fd)
             except OSError:
                 # Closing the fd implicitly releases the flock on POSIX,
                 # so swallow rather than mask the original exception.

--- a/plugins/alive/scripts/_world_root_io.py
+++ b/plugins/alive/scripts/_world_root_io.py
@@ -65,6 +65,7 @@ __all__ = (
     "read_world_root_file",
     "write_world_root_file",
     "lexical_normalize_path",
+    "windows_drive_to_msys",
 )
 
 
@@ -137,6 +138,35 @@ class WorldRootStatus(str, enum.Enum):
 # ---------------------------------------------------------------------------
 
 
+def windows_drive_to_msys(path: str):
+    """Convert a native Windows drive path to the MSYS / Git Bash mount form.
+
+    ``C:\\Users\\Ada\\world`` and ``C:/Users/Ada/world`` both become
+    ``/c/Users/Ada/world``. Mixed separators in the rest are folded to
+    ``/``. Returns ``None`` when *path* is not a drive-letter path so
+    POSIX inputs pass through unchanged.
+
+    This is the Python sibling of the bash convert in
+    ``alive-common.sh::lexical_normalize_path``. It is intentionally
+    NOT applied inside :func:`lexical_normalize_path`: that function
+    feeds ``write_world_root_file``, and on native Windows
+    ``alive doctor`` must persist ``C:\\...`` so Python ``os.path``
+    keeps treating the config as absolute. Bash converts at resolve
+    time; the stored value stays Python-native (alive#67).
+    """
+    if not path or len(path) < 3:
+        return None
+    drive = path[0]
+    if not drive.isalpha() or path[1] != ":":
+        return None
+    if path[2] not in ("\\", "/"):
+        return None
+    rest = path[3:].replace("\\", "/").lstrip("/")
+    if rest:
+        return "/" + drive.lower() + "/" + rest
+    return "/" + drive.lower()
+
+
 def lexical_normalize_path(path) -> str:
     """Lexically normalize a path. Pure string op (no fs touches).
 
@@ -153,6 +183,11 @@ def lexical_normalize_path(path) -> str:
            composition the spec calls for.
         6. Collapse a leading ``//`` (POSIX-preserved by ``normpath``)
            to ``/`` so the bash sibling stays in parity.
+
+    Windows drive-letter inputs are left to ``os.path`` on native
+    Windows (so doctor persists ``C:\\...``). The bash sibling converts
+    them to ``/c/...`` at resolve time via :func:`windows_drive_to_msys`
+    semantics; do not fold that convert in here.
 
     Returns the normalized path string. Raises ``ValueError`` for the
     rejection cases.

--- a/plugins/alive/scripts/log.py
+++ b/plugins/alive/scripts/log.py
@@ -24,7 +24,8 @@ T6 entry layout (line 2 hash-comment marker added on top of the T5 block):
 
 Lock & hook coexistence
 -----------------------
-The advisory ``fcntl.flock`` lock is acquired on a *separate* lockfile at
+The advisory lock (``fcntl.flock`` on POSIX, ``msvcrt.locking`` on
+native Windows) is acquired on a *separate* lockfile at
 ``_kernel/.log.md.lock`` and wraps ONLY the read-log/validate/compute/
 atomic-write sequence. ``project.py`` and ``generate-index.py`` run
 OUTSIDE the lock so same-walnut concurrent prepends never collide on the
@@ -67,8 +68,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -76,14 +75,15 @@ import re
 import stat as _stat_mod
 import subprocess
 import sys
-import time
 
 _SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _common import (  # noqa: E402
+    FlockTimeoutError,
     atomic_write_text,
+    flock_file,
     find_world_root,
     iso_now,
     resolve_plugin_root,
@@ -166,8 +166,10 @@ SCHEMA_METADATA = {
 
 SUBPROCESS_STDOUT_LIMIT = 2000
 
-#: Advisory ``fcntl.flock`` total wait budget (seconds) and per-retry sleep.
-#: 5s / 100ms => 50 non-blocking attempts before giving up.
+#: Advisory lock total wait budget (seconds) and per-retry sleep.
+#: 5s / 100ms => 50 non-blocking attempts before giving up. Timing is
+#: owned by ``_common.flock_file``; these names stay as documentation
+#: of the log-prepend contract.
 _LOCK_TIMEOUT_SECONDS = 5.0
 _LOCK_RETRY_INTERVAL = 0.1
 
@@ -837,30 +839,42 @@ def _run_subprocess(cmd, error_code, timeout=None):
 # ---------------------------------------------------------------------------
 
 class _FlockGuard(object):
-    """Context manager wrapping ``fcntl.flock`` on a lockfile fd.
+    """Context manager wrapping ``_common.flock_file`` on a lockfile.
 
-    Acquires ``LOCK_EX | LOCK_NB`` with a bounded retry loop so a blocked
-    writer never stalls longer than ``_LOCK_TIMEOUT_SECONDS``. Releases
-    the lock and closes the fd in ``__exit__``. On acquisition timeout
-    raises :class:`_LogError` with ``code: lock_timeout`` + ``exit 5``.
-
-    The lockfile itself is a zero-byte sentinel; the lock protects *log.md*
-    (which is written via rename and therefore cannot be flock'd directly).
+    Maps lock-backend failures onto :class:`_LogError` so prepend keeps
+    its exit-code contract (permission = 4, timeout = 5). The lockfile
+    is a sentinel; the lock protects *log.md* (written via rename).
     """
 
     def __init__(self, lock_path):
         self._lock_path = lock_path
-        self._fd = None
+        self._ctx = None
 
     def __enter__(self):
-        # O_CLOEXEC so a forked subprocess can't accidentally inherit the
-        # lock holder. O_CREAT so concurrent first-writers both succeed in
-        # creating-or-opening without a TOCTOU race. ``getattr`` guards
-        # against exotic builds that omit O_CLOEXEC (it's POSIX.1-2008
-        # but not universally re-exported through the Python os module).
-        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+        ctx = flock_file(
+            self._lock_path,
+            timeout_seconds=_LOCK_TIMEOUT_SECONDS,
+            retry_interval=_LOCK_RETRY_INTERVAL,
+        )
         try:
-            fd = os.open(self._lock_path, flags, 0o644)
+            guard = ctx.__enter__()
+        except FlockTimeoutError as exc:
+            raise _LogError(
+                "lock acquisition timed out after {}s".format(
+                    _LOCK_TIMEOUT_SECONDS
+                ),
+                code=ERROR_LOCK_TIMEOUT,
+                exit_code=5,
+                extra={
+                    "path": self._lock_path,
+                    "hint": (
+                        "another writer held the lock for "
+                        "{}s; retry or investigate".format(
+                            int(_LOCK_TIMEOUT_SECONDS)
+                        )
+                    ),
+                },
+            ) from exc
         except PermissionError as exc:
             raise _LogError(
                 "permission denied opening lockfile {}: {}".format(
@@ -877,60 +891,14 @@ class _FlockGuard(object):
                 code=ERROR_LOG_MALFORMED,
                 exit_code=1,
             ) from exc
-
-        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
-        while True:
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                self._fd = fd
-                return self
-            except BlockingIOError:
-                pass
-            except OSError as exc:
-                # EWOULDBLOCK on some kernels is distinct from EAGAIN.
-                if exc.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
-                    os.close(fd)
-                    raise _LogError(
-                        "flock failed on {}: {}".format(
-                            self._lock_path, exc
-                        ),
-                        code=ERROR_LOG_MALFORMED,
-                        exit_code=1,
-                    ) from exc
-            if time.monotonic() >= deadline:
-                os.close(fd)
-                raise _LogError(
-                    "lock acquisition timed out after {}s".format(
-                        _LOCK_TIMEOUT_SECONDS
-                    ),
-                    code=ERROR_LOCK_TIMEOUT,
-                    exit_code=5,
-                    extra={
-                        "path": self._lock_path,
-                        "hint": (
-                            "another writer held the lock for "
-                            "{}s; retry or investigate".format(
-                                int(_LOCK_TIMEOUT_SECONDS)
-                            )
-                        ),
-                    },
-                )
-            time.sleep(_LOCK_RETRY_INTERVAL)
+        self._ctx = ctx
+        return guard
 
     def __exit__(self, exc_type, exc, tb):
-        if self._fd is not None:
-            try:
-                fcntl.flock(self._fd, fcntl.LOCK_UN)
-            except OSError:
-                # Best-effort: if unlock failed, closing the fd implicitly
-                # releases the flock on POSIX. Swallow so we don't mask the
-                # original exception path.
-                pass
-            try:
-                os.close(self._fd)
-            except OSError:
-                pass
-            self._fd = None
+        if self._ctx is not None:
+            ctx = self._ctx
+            self._ctx = None
+            return ctx.__exit__(exc_type, exc, tb)
         return False
 
 

--- a/plugins/alive/statusline/alive-statusline.sh
+++ b/plugins/alive/statusline/alive-statusline.sh
@@ -6,10 +6,15 @@
 INPUT=$(cat 2>/dev/null || echo '{}')
 
 # ── Platform detection ──
+# Same prefix + MSYSTEM rules as alive-common.sh (alive#67). Statusline
+# is a standalone script and does not source the hook common file.
 ALIVE_PLATFORM="unix"
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
-  ALIVE_PLATFORM="windows"
-fi
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*|mingw*) ALIVE_PLATFORM="windows" ;;
+esac
+case "${MSYSTEM:-}" in
+  MINGW*|MSYS*|UCRT*|CLANG*) ALIVE_PLATFORM="windows" ;;
+esac
 
 # ── Pure bash JSON extraction ──
 _json_val() {

--- a/tests/release/test_file_lock.py
+++ b/tests/release/test_file_lock.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import ast
+import errno
+import multiprocessing
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "plugins" / "alive" / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+import _common as common  # noqa: E402
+
+
+def _child_hold_lock(lock_path: str, ready_path: str, release_path: str) -> None:
+    """Hold flock_file until *release_path* appears. Spawn-safe (own sys.path)."""
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _sys.path.insert(0, str(SCRIPTS))
+    import _common as _common  # noqa: PLC0415
+
+    with _common.flock_file(lock_path, timeout_seconds=5.0, retry_interval=0.05):
+        _Path(ready_path).write_text("ready", encoding="utf-8")
+        deadline = time.time() + 5.0
+        while not _Path(release_path).exists():
+            if time.time() >= deadline:
+                return
+            time.sleep(0.05)
+
+
+class _FakeMsvcrt:
+    """Minimal msvcrt.locking stand-in for Linux CI (no real MINGW)."""
+
+    LK_NBLCK = 2
+    LK_UNLCK = 3
+
+    def __init__(self) -> None:
+        self.holders = 0
+
+    def locking(self, fd, mode, nbytes):  # noqa: ARG002
+        if mode == self.LK_NBLCK:
+            if self.holders:
+                raise OSError(errno.EACCES, "Permission denied")
+            self.holders += 1
+            return None
+        if mode == self.LK_UNLCK:
+            self.holders = max(0, self.holders - 1)
+            return None
+        raise OSError(errno.EINVAL, "unknown lock mode")
+
+
+class FileLockRegressionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.base = Path(self.tempdir.name)
+
+    def test_common_and_log_do_not_bare_import_fcntl(self) -> None:
+        # Native Windows CPython: a module-level `import fcntl` (not inside
+        # try) is ModuleNotFoundError. try/except import is the fix.
+        for name in ("_common.py", "log.py"):
+            src = (SCRIPTS / name).read_text(encoding="utf-8")
+            tree = ast.parse(src)
+            for node in tree.body:
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        self.assertNotEqual(
+                            alias.name,
+                            "fcntl",
+                            "{} has an unguarded import fcntl".format(name),
+                        )
+                if isinstance(node, ast.ImportFrom) and node.module == "fcntl":
+                    self.fail("{} imports from fcntl at module level".format(name))
+
+    def test_missing_backend_is_not_a_silent_noop(self) -> None:
+        orig_f, orig_m = common._fcntl, common._msvcrt
+        try:
+            common._fcntl = None
+            common._msvcrt = None
+            with self.assertRaises(RuntimeError) as ctx:
+                common._lock_exclusive_nb(0)
+            self.assertIn("fcntl", str(ctx.exception))
+            self.assertIn("msvcrt", str(ctx.exception))
+        finally:
+            common._fcntl, common._msvcrt = orig_f, orig_m
+
+    def test_msvcrt_backend_serializes_and_times_out(self) -> None:
+        fake = _FakeMsvcrt()
+        orig_f, orig_m = common._fcntl, common._msvcrt
+        lock = self.base / "win.lock"
+        try:
+            common._fcntl = None
+            common._msvcrt = fake
+            with common.flock_file(str(lock), timeout_seconds=2.0):
+                self.assertEqual(fake.holders, 1)
+                with self.assertRaises(common.FlockTimeoutError):
+                    with common.flock_file(
+                        str(lock), timeout_seconds=0.25, retry_interval=0.05
+                    ):
+                        pass
+            self.assertEqual(fake.holders, 0)
+        finally:
+            common._fcntl, common._msvcrt = orig_f, orig_m
+
+    def test_msvcrt_lock_helpers_translate_contention(self) -> None:
+        fake = _FakeMsvcrt()
+        fd = os.open(str(self.base / "region.lock"), os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            common.msvcrt_lock_exclusive_nb(fd, fake)
+            with self.assertRaises(BlockingIOError):
+                common.msvcrt_lock_exclusive_nb(fd, fake)
+            common.msvcrt_unlock(fd, fake)
+            common.msvcrt_lock_exclusive_nb(fd, fake)
+            common.msvcrt_unlock(fd, fake)
+        finally:
+            os.close(fd)
+
+    def test_flock_file_serializes_two_processes(self) -> None:
+        # Real fcntl path on Linux CI. Threads share a flock, so this
+        # must be a second process.
+        lock = str(self.base / "posix.lock")
+        ready = str(self.base / "ready")
+        release = str(self.base / "release")
+        proc = multiprocessing.Process(
+            target=_child_hold_lock, args=(lock, ready, release)
+        )
+        proc.start()
+        deadline = time.time() + 5.0
+        while not Path(ready).exists():
+            if time.time() >= deadline:
+                proc.terminate()
+                proc.join(1)
+                self.fail("child never acquired the lock")
+            time.sleep(0.05)
+        with self.assertRaises(common.FlockTimeoutError):
+            with common.flock_file(lock, timeout_seconds=0.3, retry_interval=0.05):
+                pass
+        Path(release).write_text("go", encoding="utf-8")
+        proc.join(5)
+        self.assertEqual(proc.exitcode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/release/test_session_hooks.py
+++ b/tests/release/test_session_hooks.py
@@ -183,6 +183,37 @@ class SessionHookRegressionTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Always use midnight blue in examples", result.stdout)
 
+    def test_new_session_writes_valid_statusline_settings_json(self) -> None:
+        result = run_hook(
+            "alive-session-new.sh", self.world, "session-settings-json", "startup"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        settings = self.world / ".claude" / "settings.json"
+        self.assertTrue(settings.is_file(), "SessionStart should create settings.json")
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        command = data["statusLine"]["command"]
+        self.assertTrue(command, "statusLine.command must not be empty")
+        self.assertIn("statusline.sh", command)
+        self.assertIn("bash ", command)
+
+    def test_new_session_settings_json_survives_spaces_in_world_path(self) -> None:
+        spaced_base = self.base / "parent with spaces"
+        spaced_base.mkdir()
+        world = make_world(spaced_base)
+
+        result = run_hook(
+            "alive-session-new.sh", world, "session-settings-spaced", "startup"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        settings = world / ".claude" / "settings.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        command = data["statusLine"]["command"]
+        self.assertIn("parent with spaces", command)
+        self.assertTrue(command.startswith("bash "))
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/release/test_world_root_paths.py
+++ b/tests/release/test_world_root_paths.py
@@ -1,42 +1,209 @@
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 COMMON = ROOT / "plugins" / "alive" / "hooks" / "scripts" / "alive-common.sh"
+SCRIPTS = ROOT / "plugins" / "alive" / "scripts"
+HOOKS = ROOT / "plugins" / "alive" / "hooks" / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+from _world_root_io import lexical_normalize_path, windows_drive_to_msys  # noqa: E402
+
+
+def _bash(script: str, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", "-c", script, "bash", *args],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+        env=env,
+    )
+
+
+def _normalize_after_source(raw_path: str, prelude: str = "") -> subprocess.CompletedProcess[str]:
+    """Source alive-common.sh then normalize. *prelude* runs BEFORE source.
+
+    SessionStart does not pass ALIVE_PLATFORM; the hook computes it while
+    sourcing. Tests that want MINGW64 must set OSTYPE/MSYSTEM/MACHTYPE in
+    *prelude*, not after source -- bash overwrites OSTYPE at process
+    start, so a parent-env OSTYPE=msys never reaches Linux bash.
+    """
+    return _bash(
+        prelude + 'source "$1"; printf "PLATFORM=%s\\n" "$ALIVE_PLATFORM"; lexical_normalize_path "$2"',
+        str(COMMON),
+        raw_path,
+    )
+
+
+class MingwPlatformDetectionTest(unittest.TestCase):
+    """alive#67: the 3.2.1 convert is gated on ALIVE_PLATFORM=windows.
+
+    SessionStart runs `bash .../alive-session-new.sh` (hooks.json) and
+    sources alive-common.sh. Claude does not set the flag. If detection
+    misses MINGW64, the convert is dead.
+    """
+
+    def test_ostype_msys_sets_windows_and_converts_backslash_path(self) -> None:
+        result = _normalize_after_source(
+            r"C:\Users\Ada\Alive World",
+            prelude='OSTYPE=msys; MSYSTEM=MINGW64; MACHTYPE=x86_64-pc-cygwin; ',
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = result.stdout.strip().splitlines()
+        self.assertEqual(lines[0], "PLATFORM=windows")
+        self.assertEqual(lines[-1], "/c/Users/Ada/Alive World")
+
+    def test_ostype_msys2_prefix_sets_windows(self) -> None:
+        # Exact `OSTYPE == msys` (3.2.1) misses this; prefix match must not.
+        result = _normalize_after_source(
+            r"C:\Users\Ada\alive",
+            prelude="OSTYPE=msys2; ",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("PLATFORM=windows", result.stdout)
+        self.assertTrue(result.stdout.strip().endswith("/c/Users/Ada/alive"))
+
+    def test_msystem_mingw64_sets_windows_even_if_ostype_looks_unix(self) -> None:
+        result = _normalize_after_source(
+            "D:/Context/World",
+            prelude="OSTYPE=linux-gnu; MSYSTEM=MINGW64; ",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("PLATFORM=windows", result.stdout)
+        self.assertTrue(result.stdout.strip().endswith("/d/Context/World"))
+
+    def test_machtype_cygwin_sets_windows(self) -> None:
+        result = _normalize_after_source(
+            r"C:\Users\Ada\alive",
+            prelude="OSTYPE=linux-gnu; unset MSYSTEM; MACHTYPE=x86_64-pc-cygwin; ",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("PLATFORM=windows", result.stdout)
+
+    def test_linux_source_leaves_unix_and_rejects_drive_path(self) -> None:
+        result = _normalize_after_source(
+            r"C:\Users\Ada\alive",
+            prelude="OSTYPE=linux-gnu; unset MSYSTEM; MACHTYPE=x86_64-pc-linux-gnu; ",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("PLATFORM=unix", result.stdout)
 
 
 class BashWorldRootPathRegressionTest(unittest.TestCase):
+    """Convert itself: C:\\ and C:/ both become /c/... when the flag is set.
+
+    Public 3.2.1 already had this convert. These tests exercise it the way
+    SessionStart does (flag from detection), plus mixed separators.
+    """
+
     def normalize_as_windows(self, raw_path: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [
-                "bash",
-                "-c",
-                'source "$1"; ALIVE_PLATFORM=windows; lexical_normalize_path "$2"',
-                "bash",
-                str(COMMON),
-                raw_path,
-            ],
-            text=True,
-            capture_output=True,
-            timeout=30,
-            check=False,
+        return _bash(
+            'source "$1"; ALIVE_PLATFORM=windows; lexical_normalize_path "$2"',
+            str(COMMON),
+            raw_path,
         )
 
     def test_native_windows_backslash_path_converts_to_msys_mount(self) -> None:
         result = self.normalize_as_windows(r"C:\Users\Ada\Alive World")
-
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "/c/Users/Ada/Alive World")
 
     def test_native_windows_forward_slash_path_converts_to_msys_mount(self) -> None:
         result = self.normalize_as_windows("D:/Context/World")
-
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "/d/Context/World")
+
+    def test_mixed_separators_fold_to_msys_mount(self) -> None:
+        result = self.normalize_as_windows(r"C:\Users/Ada\world")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "/c/Users/Ada/world")
+
+    def test_posix_absolute_path_is_unchanged(self) -> None:
+        result = self.normalize_as_windows("/home/ada/alive")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "/home/ada/alive")
+
+    def test_relative_path_still_rejected(self) -> None:
+        result = self.normalize_as_windows("Users/Ada/alive")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_persisted_windows_config_is_not_corrupt_when_platform_is_windows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "world-root"
+            cfg.write_text(r"C:\Users\Ada\Alive World" + "\n", encoding="utf-8")
+            result = _bash(
+                'OSTYPE=msys; MSYSTEM=MINGW64; source "$1"; _alive_parse_persisted_world_root_file "$2"',
+                str(COMMON),
+                str(cfg),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "/c/Users/Ada/Alive World")
+
+    def test_python_helper_matches_bash_windows_convert(self) -> None:
+        cases = (
+            (r"C:\Users\Ada\Alive World", "/c/Users/Ada/Alive World"),
+            ("C:/Users/Ada/Alive World", "/c/Users/Ada/Alive World"),
+            (r"C:\Users/Ada\world", "/c/Users/Ada/world"),
+            (r"e:\alive", "/e/alive"),
+        )
+        for raw, expected in cases:
+            self.assertEqual(windows_drive_to_msys(raw), expected, raw)
+            result = self.normalize_as_windows(raw)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), expected)
+
+    def test_python_helper_leaves_posix_and_relative_alone(self) -> None:
+        self.assertIsNone(windows_drive_to_msys("/home/ada/alive"))
+        self.assertIsNone(windows_drive_to_msys("Users/Ada"))
+        self.assertIsNone(windows_drive_to_msys("C:Users"))
+        self.assertIsNone(windows_drive_to_msys(""))
+
+    def test_python_lexical_normalize_does_not_rewrite_drive_paths_on_posix(self) -> None:
+        # write_world_root_file calls lexical_normalize_path. Folding C:\
+        # into /c/ here would persist an MSYS path that native Windows
+        # Python doctor then treats as C:\c\... .
+        if os.name == "nt":
+            self.skipTest("native Windows os.path already accepts C:\\")
+        with self.assertRaises(ValueError):
+            lexical_normalize_path(r"C:\Users\Ada\alive")
+        with self.assertRaises(ValueError):
+            lexical_normalize_path("C:/Users/Ada/alive")
+
+
+class StatuslineJsonEncodeTest(unittest.TestCase):
+    def encode(self, value: str) -> subprocess.CompletedProcess[str]:
+        return _bash(
+            'source "$1"; alive_json_encode_string "$2"',
+            str(COMMON),
+            value,
+        )
+
+    def test_encode_round_trips_spaces_and_quotes(self) -> None:
+        raw = 'bash "/c/Users/Ada/Alive World/.alive/statusline.sh"'
+        result = self.encode(raw)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        encoded = result.stdout.strip()
+        self.assertEqual(json.loads(encoded), raw)
+
+    def test_session_new_does_not_use_nested_double_quoted_python_c(self) -> None:
+        text = (HOOKS / "alive-session-new.sh").read_text(encoding="utf-8")
+        self.assertNotIn(
+            'decode("utf-8","replace")))" 2>/dev/null',
+            text,
+        )
+        self.assertIn("alive_json_encode_string", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Component:** hook / runtime
**Breaking:** no — walnut layout, workstreams, logs, and adapter surfaces are unchanged.

Fixes #67 (francescostanzo1-hub, plugin 3.2.0, MINGW64, no WSL). Targeted public-trunk patch only.

## How to try this branch (reporter)

You are still on 3.2.0. This branch is the cloneable Windows-native fix — do not wait for a marketplace release.

**Clone path (recommended):**

```bash
git clone --branch fix/windows-native https://github.com/alivecontext/alive.git
claude plugin install /path/to/alive
```

Then restart Claude Code in Git Bash and open a session in an existing world. SessionStart should resolve the world (no `NO WORLD FOUND / fresh install`), `.claude/settings.json` should stay valid JSON with a non-empty `statusLine.command`, and `alive` CLI scripts should import without `ModuleNotFoundError: No module named 'fcntl'`.

**Marketplace from the branch:** Claude Code marketplaces follow the repo default branch, so a marketplace add of `alivecontext/alive` still installs 3.2.1 from `main`. To load this PR, either install the clone path above or add the clone as a local marketplace:

```bash
claude plugin marketplace add /path/to/alive
claude plugin install alive@alivecontext
```

Please paste `echo "$OSTYPE $MSYSTEM $MACHTYPE"` from that Git Bash if anything still fails.

## What changed

1. **SessionStart / `ALIVE_PLATFORM`.** Public 3.2.1 already converts `C:\` / `C:/` → `/c/...` when `ALIVE_PLATFORM=windows`. SessionStart does not pass that flag (`hooks.json` runs `bash .../alive-session-new.sh`, which sources `alive-common.sh`). Exact `OSTYPE == msys` missed `msys2` and ignored `MSYSTEM=MINGW64` / cygwin `MACHTYPE` (the reporter's Git Bash 5.3 fingerprint). Detection now uses prefixes + `MSYSTEM` + `MACHTYPE` and exports the flag. Config may stay `C:\` for Python; bash accepts it.
2. **Statusline quoting.** Once `find_world` succeeds, nested `python3 -c` double quotes expand empty on Git Bash and write `"command":` with no value (malformed `.claude/settings.json`). Encode via single-quoted `alive_json_encode_string`.
3. **`import fcntl`.** Native Windows CPython has no `fcntl`. `_common.py` / `log.py` use `fcntl.flock` on POSIX and `msvcrt.locking` on Windows. Neither backend → `RuntimeError`, not a silent no-op.

## Why

Reporter reproduced the POSIX-only reject (`C:\` stored by Python, bash `[ "${p:0:1}" != "/" ] && return 1` → `corrupt_config_file` → NO WORLD FOUND). The convert existed; the flag was never set on MINGW SessionStart. The two follow-ons only show up after `find_world` works.

## Verification

- [x] Targeted tests added (see honesty notes)
- [ ] Real MINGW64 walnut — **needs the reporter**
- [x] File contract unchanged
- [x] No PII

### Green vs theater

**Green (Linux CI can prove):**

- Simulated MINGW64 env (`OSTYPE=msys`, `MSYSTEM=MINGW64`, `MACHTYPE=x86_64-pc-cygwin`) sets `ALIVE_PLATFORM=windows` at source time and converts `C:\…`
- `OSTYPE=msys2` prefix and `MSYSTEM=MINGW64` with a unix-looking `OSTYPE` also set the flag
- Linux source leaves `unix` and still rejects `C:\` (doctor does not persist `/c/…`)
- Convert of `C:\`, `C:/`, mixed separators when the flag is set
- `alive_json_encode_string` round-trips; SessionStart writes parseable `settings.json` with a non-empty `command`
- `flock_file` serializes two processes on real `fcntl`; fake `msvcrt` contention times out; missing both backends raises; no unguarded `import fcntl`

**Not proven (Linux CI cannot prove MINGW):**

- Real Git Bash 5.3 on the reporter's box (`echo "$OSTYPE $MSYSTEM $MACHTYPE"` still wanted)
- Real `msvcrt.locking` across two native Windows Python processes
- End-to-end Claude Code tab after statusline injection

## Session context

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1025c3a-a61d-4eee-b557-ba387d115679?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1025c3a-a61d-4eee-b557-ba387d115679&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

