### PR TITLE
fix: native Windows settings.json corruption + fcntl crash

### DIFF
--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -222,7 +222,7 @@ fix_statusline_in_settings() {
 {
   "statusLine": {
     "type": "command",
-    "command": $( if [ "$ALIVE_JSON_RT" = "python3" ]; then printf '%s' "$STATUSLINE_CMD" | python3 -c "import sys,json; print(json.dumps(sys.stdin.buffer.read().decode("utf-8","replace")))" 2>/dev/null; elif [ "$ALIVE_JSON_RT" = "node" ]; then printf '%s' "$STATUSLINE_CMD" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.stringify(d)))" 2>/dev/null; else echo "\"$STATUSLINE_CMD\""; fi )
+    "command": $( if [ "$ALIVE_JSON_RT" = "python3" ]; then printf '%s' "$STATUSLINE_CMD" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.buffer.read().decode("utf-8","replace")))' 2>/dev/null; elif [ "$ALIVE_JSON_RT" = "node" ]; then printf '%s' "$STATUSLINE_CMD" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.stringify(d)))" 2>/dev/null; else echo "\"$STATUSLINE_CMD\""; fi )
   }
 }
 SETTINGSEOF

--- a/plugins/alive/scripts/_common.py
+++ b/plugins/alive/scripts/_common.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 import contextlib
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -792,6 +791,48 @@ def resolve_session_id(override=None):
 # Advisory file locking (fcntl.flock context manager + ownership token)
 # ---------------------------------------------------------------------------
 
+# fcntl isn't available on native Windows (MSYS/Git Bash python3 still
+# lacks it). msvcrt.locking() is the closest equivalent but locks a byte
+# range rather than the whole file and signals contention differently.
+# Every caller here locks a dedicated sentinel file, never the data file
+# itself, so locking a single byte at offset 0 is sufficient and keeps
+# every call site below unchanged (LOCK_EX/LOCK_NB/LOCK_UN + flock()).
+try:
+    import fcntl as _fcntl
+
+    LOCK_EX = _fcntl.LOCK_EX
+    LOCK_NB = _fcntl.LOCK_NB
+    LOCK_UN = _fcntl.LOCK_UN
+
+    def flock(fd, flags):
+        _fcntl.flock(fd, flags)
+
+except ImportError:  # pragma: no cover - native Windows only
+    import msvcrt as _msvcrt
+
+    LOCK_EX = 1
+    LOCK_NB = 2
+    LOCK_UN = 4
+
+    def flock(fd, flags):
+        pos = os.lseek(fd, 0, os.SEEK_CUR)
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            if flags & LOCK_UN:
+                mode = _msvcrt.LK_UNLCK
+            elif flags & LOCK_NB:
+                mode = _msvcrt.LK_NBLCK
+            else:
+                mode = _msvcrt.LK_LOCK
+            try:
+                _msvcrt.locking(fd, mode, 1)
+            except OSError as exc:
+                if (flags & LOCK_NB) and not (flags & LOCK_UN):
+                    raise BlockingIOError(errno.EAGAIN, str(exc)) from exc
+                raise
+        finally:
+            os.lseek(fd, pos, os.SEEK_SET)
+
 #: Default total wait budget (seconds) and per-retry sleep for flock_file.
 #: 5s / 100ms => 50 non-blocking attempts before giving up. Tuned to match
 #: the log.py lock acquisition timing so promote.py and tasks.py share the
@@ -894,7 +935,7 @@ def flock_file(
         deadline = time.monotonic() + float(timeout_seconds)
         while True:
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                flock(fd, LOCK_EX | LOCK_NB)
                 break
             except BlockingIOError:
                 pass
@@ -913,7 +954,7 @@ def flock_file(
             yield guard
         finally:
             try:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                flock(fd, LOCK_UN)
             except OSError:
                 # Closing the fd implicitly releases the flock on POSIX,
                 # so swallow rather than mask the original exception.

--- a/plugins/alive/scripts/log.py
+++ b/plugins/alive/scripts/log.py
@@ -68,7 +68,6 @@ from __future__ import annotations
 
 import argparse
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -83,8 +82,12 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _common import (  # noqa: E402
+    LOCK_EX,
+    LOCK_NB,
+    LOCK_UN,
     atomic_write_text,
     find_world_root,
+    flock,
     iso_now,
     resolve_plugin_root,
     resolve_session_id,
@@ -881,7 +884,7 @@ class _FlockGuard(object):
         deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
         while True:
             try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                flock(fd, LOCK_EX | LOCK_NB)
                 self._fd = fd
                 return self
             except BlockingIOError:
@@ -920,7 +923,7 @@ class _FlockGuard(object):
     def __exit__(self, exc_type, exc, tb):
         if self._fd is not None:
             try:
-                fcntl.flock(self._fd, fcntl.LOCK_UN)
+                flock(self._fd, LOCK_UN)
             except OSError:
                 # Best-effort: if unlock failed, closing the fd implicitly
                 # releases the flock on POSIX. Swallow so we don't mask the


### PR DESCRIPTION
Fixes #79 and #80, both found by @francescostanzo1-hub while debugging #67.

- **#79** — the statusline `python3 -c` one-liner in `alive-session-new.sh` had unescaped nested double quotes inside an already-double-quoted string, so bash truncated the argument early on native Windows, writing an empty `"command"` value and corrupting `settings.json` for every tab after. Fixed by switching the outer quoting to single quotes.
- **#80** — `_common.py` / `log.py` both did an unconditional `import fcntl`, which crashes on native Windows. Added a small `flock()`/`LOCK_EX`/`LOCK_NB`/`LOCK_UN` compat shim in `_common.py` (msvcrt.locking on a 1-byte range when fcntl is unavailable — every caller locks a dedicated sentinel file, never the data file, so this is sufficient), `log.py` now imports the shim instead of `fcntl` directly.

Full suite green except one pre-existing, unrelated failure (CLAUDE.md skill-list drift).