### PR TITLE
fix: project.py unscoped fallback resurfaces finished urgent tasks

### DIFF
--- a/plugins/alive/scripts/project.py
+++ b/plugins/alive/scripts/project.py
@@ -658,6 +658,12 @@ def assemble(walnut):
             status = t.get("status", "todo")
             priority = t.get("priority", "todo")
             title = t.get("title", "")
+            # Done/dropped tasks are history, not open work (issue #73).
+            # tasks.py summary already filters these; the direct-read
+            # fallback must apply the same contract or it resurfaces
+            # finished-but-once-urgent tasks as urgent in now.json.
+            if status in ("done", "dropped"):
+                continue
             if priority == "urgent":
                 u_urgent.append(title)
                 u_counts["urgent"] += 1

--- a/tests/release/test_issue_72_73_summaries.py
+++ b/tests/release/test_issue_72_73_summaries.py
@@ -155,6 +155,52 @@ class SummaryRegressionTest(unittest.TestCase):
         self.assertEqual(unscoped["urgent"], [])
         self.assertEqual(unscoped["counts"]["todo"], 1)
 
+    def test_issue_73_projection_fallback_excludes_finished_unscoped(self) -> None:
+        """project.py's direct-read fallback must also skip done/dropped.
+
+        assemble() only takes the direct_unscoped fallback path when
+        tasks.py summary's own unscoped counts are all zero (see
+        ``total_unscoped == 0 and direct_unscoped`` in project.py) -- so
+        the repro walnut must hold *only* finished-but-once-urgent tasks
+        at the kernel level (no open unscoped work), or the fallback
+        branch is never reached and this test would pass for the wrong
+        reason regardless of the fix. That's the exact shape of issue #73:
+        a kernel tasks.json holding only finished-but-once-urgent tasks
+        resurfaced as urgent in now.json, reachable through the primary
+        ``project.py --walnut`` path the load skill reads on every
+        session start.
+        """
+        finished_only = Path(self._tmp.name) / "finished-only"
+        kernel = finished_only / "_kernel"
+        kernel.mkdir(parents=True)
+        (kernel / "key.md").write_text("# key\n", encoding="utf-8")
+        (kernel / "tasks.json").write_text(
+            json.dumps(
+                {
+                    "tasks": [
+                        {
+                            "id": "d1",
+                            "title": "was urgent now done",
+                            "priority": "urgent",
+                            "status": "done",
+                        },
+                        {
+                            "id": "d2",
+                            "title": "was urgent now dropped",
+                            "priority": "urgent",
+                            "status": "dropped",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        now = PROJECT.assemble(str(finished_only))
+        unscoped = now["unscoped_tasks"]
+        self.assertEqual(unscoped["counts"]["urgent"], 0)
+        self.assertEqual(unscoped["urgent"], [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #73.

`tasks.py summary` already filters done/dropped tasks before priority bucketing, but `project.py`'s `assemble()` re-reads the walnut `tasks.json` directly as a fallback when the summary's own unscoped counts are all zero (`total_unscoped == 0 and direct_unscoped`). That fallback never applied the same filter, so a kernel `tasks.json` holding only finished-but-once-urgent tasks resurfaced them as urgent in `now.json` — reachable through the primary `project.py --walnut` path the load skill reads on every session start.

Regression test isolates the fallback's actual trigger condition (a walnut with *only* finished tasks at the kernel level, no other unscoped work) — confirmed it fails without the fix (2 phantom urgent tasks) and passes with it.

Full suite green except the one pre-existing, unrelated CLAUDE.md skill-list drift failure.