### PR TITLE
fix: bump claude-code-action v1.0.112 -> v1.0.201

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.112  # pinned to last-known-good SHA 2cc1ac13 (Claude Code 2.1.128); v1.0.113 broke install on hosted runners
+        uses: anthropics/claude-code-action@v1.0.201  # pinned to commit c81e3bc6 (bumped 2026-08-24; v1.0.112 was throwing an internal "directory mismatch" error on every run)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-pii-review.yml
+++ b/.github/workflows/claude-pii-review.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Claude PII Review
         id: claude-pii-review
-        uses: anthropics/claude-code-action@v1.0.112  # pinned to last-known-good SHA 2cc1ac13 (Claude Code 2.1.128); v1.0.113 broke install on hosted runners
+        uses: anthropics/claude-code-action@v1.0.201  # pinned to commit c81e3bc6 (bumped 2026-08-24; v1.0.112 was throwing an internal "directory mismatch" error on every run)
         env:
           # Optional watchlist. If the PII_WATCHLIST_JSON secret is unset, we
           # pass an empty-structured object so the prompt can parse it cleanly

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.112  # pinned to last-known-good SHA 2cc1ac13 (Claude Code 2.1.128); v1.0.113 broke install on hosted runners
+        uses: anthropics/claude-code-action@v1.0.201  # pinned to commit c81e3bc6 (bumped 2026-08-24; v1.0.112 was throwing an internal "directory mismatch" error on every run)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <p align="center">
+  <a href="https://github.com/alivecontext/alive/actions/workflows/release-tests.yml"><img src="https://github.com/alivecontext/alive/actions/workflows/release-tests.yml/badge.svg" alt="Release Tests"></a>
   <a href="https://github.com/alivecontext/alive/releases"><img src="https://img.shields.io/badge/version-3.2.1-F97316?style=flat" alt="Version"></a>
   <a href="https://github.com/alivecontext/alive/stargazers"><img src="https://img.shields.io/github/stars/alivecontext/alive?style=flat&color=F97316&label=Stars" alt="GitHub Stars"></a>
   <a href="https://github.com/alivecontext/alive/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>


### PR DESCRIPTION
The pinned action version was ~90 releases stale and throwing an internal \`directory mismatch for directory .../tsconfig.json\` error on every single run — both \`claude-review\` and \`pii-review\` have been failing on every PR regardless of the diff. Confirmed by reading the actual run logs; the credential (\`CLAUDE_CODE_OAUTH_TOKEN\`) was never the problem.

The pin comment cited "v1.0.113 broke hosted-runner installs" as the reason for staying on v1.0.112 — that regression is presumably long fixed 90 releases later. Testing the bump live via this PR's own checks below.