### PR TITLE
ci: authenticate claude workflows with ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1.0.201  # pinned to commit c81e3bc6 (bumped 2026-08-24; v1.0.112 was throwing an internal "directory mismatch" error on every run)
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           # Resolve PR number from whichever event fired the workflow.

--- a/.github/workflows/claude-pii-review.yml
+++ b/.github/workflows/claude-pii-review.yml
@@ -53,7 +53,7 @@ jobs:
           # and fall back to pure judgment-based detection.
           PII_WATCHLIST_JSON: ${{ secrets.PII_WATCHLIST_JSON || '{"names":[],"businesses":[]}' }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ steps.load_prompt.outputs.prompt }}
           use_sticky_comment: true
           # Inline-comment MCP server and the gh subcommands the prompt needs.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1.0.201  # pinned to commit c81e3bc6 (bumped 2026-08-24; v1.0.112 was throwing an internal "directory mismatch" error on every run)
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
all three claude workflows passed claude_code_oauth_token from an april-dated oauth token that expired months ago - every review run died in ~300ms with is_error:true and zero cost. the ANTHROPIC_API_KEY secret (set 2026-09-10) was never referenced.

swaps all three to anthropic_api_key. this PR's own claude-review run is the live test.