### PR TITLE
feat: session-start index brief

### DIFF
--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -334,10 +334,85 @@ if [ -f "$GENERATOR" ] && [ "$ALIVE_JSON_RT" = "python3" ]; then
   touch "/tmp/alive-index-regen" 2>/dev/null || true
 fi
 
-# Read world index (.alive/_index.yaml) for injection -- walnut registry
+# World index brief for injection (issue #89) -- the model needs the
+# registry (what exists, where, who), not the full metadata. Names,
+# paths, phase and people fit in ~6KB where the full index runs 39KB+
+# on a mature world and scales with it. Goals, tags, capsule lists and
+# session summaries stay on disk (.alive/_index.yaml), one read away.
+# Falls back to the full index only when _index.json is missing.
 WORLD_INDEX_CONTENT=""
+WORLD_INDEX_JSON="$WORLD_ROOT/.alive/_index.json"
 WORLD_INDEX_FILE="$WORLD_ROOT/.alive/_index.yaml"
-if [ -f "$WORLD_INDEX_FILE" ]; then
+BRIEF=""
+if [ -f "$WORLD_INDEX_JSON" ]; then
+  if [ "$ALIVE_JSON_RT" = "python3" ]; then
+    BRIEF=$(ALIVE_INDEX="$WORLD_INDEX_JSON" python3 -c '
+import json, os
+try:
+    d = json.load(open(os.environ["ALIVE_INDEX"], encoding="utf-8"))
+except Exception:
+    raise SystemExit
+out = []
+w = d.get("walnuts") or {}
+entries = list(w.values()) if isinstance(w, dict) else list(w)
+by_domain = {}
+for e in entries:
+    if not isinstance(e, dict):
+        continue
+    path = (e.get("path") or "").strip()
+    if not path:
+        continue
+    name = e.get("name") or path.rstrip("/").rsplit("/", 1)[-1]
+    phase = e.get("phase") or ""
+    domain = "archive" if path.startswith("01_Archive") else (e.get("domain") or "other")
+    by_domain.setdefault(domain, []).append((name, path, phase))
+out.append(f"walnuts: {len(entries)}")
+for domain in sorted(by_domain):
+    rows = by_domain[domain]
+    if domain == "archive":
+        out.append(f"archive: {len(rows)} walnuts (not listed; read .alive/_index.yaml if needed)")
+        continue
+    out.append(f"{domain}:")
+    for name, path, phase in sorted(rows):
+        suffix = f"  [{phase}]" if phase else ""
+        out.append(f"  {name}  {path}{suffix}")
+p = d.get("people") or {}
+pentries = list(p.values()) if isinstance(p, dict) else list(p)
+pnames = []
+for e in pentries:
+    if not isinstance(e, dict):
+        continue
+    path = (e.get("path") or "").strip()
+    if path.startswith("01_Archive"):
+        continue
+    pnames.append(e.get("name") or path.rstrip("/").rsplit("/", 1)[-1])
+out.append(f"people ({len(pnames)}): " + ", ".join(sorted(set(pnames))))
+rs = d.get("recent_sessions") or []
+if rs:
+    out.append("recent_sessions:")
+    for s in rs[:3]:
+        if not isinstance(s, dict):
+            continue
+        summary = (s.get("summary") or "").strip().replace("\n", " ")
+        if len(summary) > 160:
+            summary = summary[:157] + "..."
+        date = s.get("date", "?")
+        wal = s.get("walnut") or "(no walnut)"
+        out.append(f"  {date}  {wal}  {summary}")
+stats = d.get("stats") or {}
+uws = stats.get("unsaved_with_stash") or d.get("unsaved_with_stash")
+if uws:
+    out.append(f"unsaved_with_stash: {uws}")
+out.append("Full registry with goals, tags, bundles and session history: .alive/_index.yaml (read on demand).")
+print("\n".join(out))
+' 2>/dev/null)
+  fi
+fi
+if [ -n "$BRIEF" ]; then
+  WORLD_INDEX_CONTENT="<WORLD_INDEX_BRIEF>
+$BRIEF
+</WORLD_INDEX_BRIEF>"
+elif [ -f "$WORLD_INDEX_FILE" ]; then
   WORLD_INDEX_CONTENT="<WORLD_INDEX>
 $(cat "$WORLD_INDEX_FILE")
 </WORLD_INDEX>"

--- a/plugins/alive/skills/world/SKILL.md
+++ b/plugins/alive/skills/world/SKILL.md
@@ -14,7 +14,7 @@ NOT a database dump. NOT a flat list. A living view of their world, grouped by w
 
 ## Load Sequence
 
-1. **Read the injected `<WORLD_INDEX>`** — it's already in your session context from the SessionStart hook. Contains every walnut's type, goal, phase, rhythm, updated, people, links, tags, bundles, and parent relationships. Zero file reads needed. If `<WORLD_INDEX>` is not in context, fall back to reading `.alive/_index.yaml` directly.
+1. **Read `.alive/_index.yaml`** — one read, everything the dashboard needs: every walnut's type, goal, phase, rhythm, updated, people, links, tags, bundles, and parent relationships. The SessionStart hook injects `<WORLD_INDEX_BRIEF>` (names, paths, phases, people) which is enough to orient, but the dashboard's goal lines, rhythm warnings and bundle counts come from the full index file. Older plugin versions injected the full index as `<WORLD_INDEX>`; if that's in context, use it and skip the read.
 2. **If no index exists at all** — generate it first (`python3 "$ALIVE_PLUGIN_ROOT/scripts/generate-index.py" "$WORLD_ROOT"`), then read the output. Fall back to manual scanning only on first-time setup before the index infrastructure exists.
 3. **Freshness check** — read the `generated:` timestamp from the index. Display it in the dashboard header. If older than 10 minutes, show a warning. If older than 1 hour, suggest regeneration. This makes index staleness visible instead of invisible.
 4. Build the tree from the index — parent/child relationships from `parent:` field
@@ -69,7 +69,7 @@ When the background agent completes, surface the results:
 
 The triage agent gets the world index in its prompt so it knows every walnut, person, and active bundle. It matches by name, keywords, and file type patterns. It does NOT move files — it suggests. The human confirms.
 
-**DO NOT read preferences.yaml** — it's already injected at session start. **DO NOT read individual walnut files** (key.md, now.json, log.md) — the index has everything. **DO NOT read .alive/_squirrels/*.yaml files** — recent sessions are in the index under `recent_sessions:` and unsaved stash count is in `unsaved_with_stash:`. **DO NOT spawn Explore agents or subagents** for the dashboard — use the index and the one bash check above. The entire dashboard should render from data already in context plus 1 fast bash call (inputs listing).
+**DO NOT read preferences.yaml** — it's already injected at session start. **DO NOT read individual walnut files** (key.md, now.json, log.md) — the index has everything. **DO NOT read .alive/_squirrels/*.yaml files** — recent sessions are in the index under `recent_sessions:` and unsaved stash count is in `unsaved_with_stash:`. **DO NOT spawn Explore agents or subagents** for the dashboard — use the index and the one bash check above. The entire dashboard should render from the injected brief plus 1 index-file read plus 1 fast bash call (inputs listing).
 
 ## State Detection
 

--- a/tests/release/test_issue_89_brief.py
+++ b/tests/release/test_issue_89_brief.py
@@ -1,0 +1,127 @@
+"""Regression tests for issue #89 (session-start injection diet).
+
+SessionStart previously injected the full ``_index.yaml`` — 39KB+ on a
+mature world, scaling with walnut count, mostly metadata the model can
+read on demand. The hook now injects a brief built from ``_index.json``:
+walnut names, paths and phases grouped by domain, people names, recent
+sessions and counts. Goals, tags and capsule lists stay on disk.
+
+The hook regenerates the index synchronously at session start, so these
+tests build real walnut directories and let the generator produce the
+index the brief is derived from. (The full-index fallback for worlds
+where ``_index.json`` cannot be produced is a code path, not covered
+here — it requires a python3-less environment.)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN = ROOT / "plugins" / "alive"
+HOOKS = PLUGIN / "hooks" / "scripts"
+
+
+def run_session_new(world: Path, session_id: str) -> str:
+    payload = {
+        "session_id": session_id,
+        "cwd": str(world),
+        "hook_event_name": "SessionStart",
+        "model": "test-model",
+        "source": "startup",
+        "transcript_path": str(world / "transcript.jsonl"),
+    }
+    env = os.environ.copy()
+    env.update(
+        {
+            "ALIVE_WORLD_ROOT_OVERRIDE": str(world),
+            "CLAUDE_PLUGIN_ROOT": str(PLUGIN),
+            "CLAUDE_ENV_FILE": str(world / ".claude-env"),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(HOOKS / "alive-session-new.sh")],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        cwd=world,
+        env=env,
+    )
+    output = json.loads(result.stdout)
+    return output["hookSpecificOutput"]["additionalContext"]
+
+
+def write_walnut(root: Path, rel: str, goal: str, phase: str = "building") -> None:
+    kernel = root / rel / "_kernel"
+    kernel.mkdir(parents=True)
+    (kernel / "key.md").write_text(
+        "---\n"
+        "type: venture\n"
+        f"goal: {goal}\n"
+        "created: 2026-09-01\n"
+        "rhythm: weekly\n"
+        "tags: [tag-not-injected]\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    (kernel / "now.json").write_text(
+        json.dumps({"phase": phase, "squirrel": "someone"}), encoding="utf-8"
+    )
+
+
+class SessionStartBriefTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.world = Path(self._tmp.name) / "world"
+        (self.world / ".alive" / "_squirrels").mkdir(parents=True)
+        (self.world / ".alive" / "preferences.yaml").write_text(
+            "github_star_ask: false\n", encoding="utf-8"
+        )
+        (self.world / "03_Inbox").mkdir()
+        write_walnut(self.world, "04_Ventures/my-venture", "SECRET-GOAL-TEXT here")
+        write_walnut(
+            self.world, "01_Archive/04_Ventures/old-thing", "archived goal", "dead"
+        )
+        person = self.world / "02_Life" / "people" / "jane-doe" / "_kernel"
+        person.mkdir(parents=True)
+        (person / "key.md").write_text(
+            "---\ntype: person\ngoal: knows things\n---\n", encoding="utf-8"
+        )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_brief_injected_with_registry_but_no_metadata(self) -> None:
+        context = run_session_new(self.world, "brief-test-1")
+
+        self.assertIn("<WORLD_INDEX_BRIEF>", context)
+        self.assertIn("my-venture", context)
+        self.assertIn("04_Ventures/my-venture", context)
+        self.assertIn("jane-doe", context)
+        # metadata stays on disk, one read away
+        self.assertNotIn("SECRET-GOAL-TEXT", context)
+        self.assertNotIn("tag-not-injected", context)
+        # archived walnuts are counted, not listed
+        self.assertNotIn("01_Archive/04_Ventures/old-thing", context)
+        # the full index is no longer injected
+        self.assertNotIn("<WORLD_INDEX>\n", context)
+        # and it still exists on disk for on-demand reads
+        self.assertTrue((self.world / ".alive" / "_index.yaml").exists())
+
+    def test_brief_is_materially_smaller_than_full_index(self) -> None:
+        context = run_session_new(self.world, "brief-test-2")
+        start = context.index("<WORLD_INDEX_BRIEF>")
+        end = context.index("</WORLD_INDEX_BRIEF>")
+        brief_size = end - start
+        full_size = (self.world / ".alive" / "_index.yaml").stat().st_size
+        self.assertLess(brief_size, full_size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
part of #89 (leaves it open - rules diet and system-upgrade additions still to come)

session start injected the entire _index.yaml into model context - 39KB on a 49-walnut world, scaling forever with world size. most of it is metadata the model can read on demand once it knows a thing exists.

the hook now derives a brief from _index.json: walnut names + paths + phases grouped by domain, people names, 3 recent sessions, counts. 4.6KB on the same world - 88% cut with the full registry one read away. archived walnuts are counted, not listed. worlds without _index.json fall back to the old full-index injection.

the world skill reads .alive/_index.yaml for its dashboard now (one read) instead of expecting everything pre-injected.

2 integration tests - real walnut dirs, real generator run, asserts names/people present, goals/tags absent, brief smaller than the full index.