### PR TITLE
fix: tasks.py id-collision data loss

### DIFF
--- a/plugins/alive/scripts/tasks.py
+++ b/plugins/alive/scripts/tasks.py
@@ -496,8 +496,21 @@ def _upgrade_v2_json(json_path):
     # Map v2 priority values to v3
     priority_map = {"normal": "todo", "urgent": "urgent", "active": "active"}
 
+    # Continue after the highest id already present in the file -- a
+    # counter starting at 1 collides with existing v3 ids in mixed
+    # files, and duplicate ids make id-based mutation destructive
+    # (t140: done/drop removed every task sharing the id).
+    max_existing = 0
+    for t in tasks:
+        tid = t.get("id")
+        if isinstance(tid, str) and tid.startswith("t"):
+            try:
+                max_existing = max(max_existing, int(tid[1:]))
+            except ValueError:
+                pass
+
     upgraded = []
-    counter = 1
+    counter = max_existing + 1
     for t in tasks:
         if "text" in t and "id" not in t:
             v2_priority = t.get("priority", "todo")
@@ -513,10 +526,10 @@ def _upgrade_v2_json(json_path):
                 "created": _today(),
                 "session": t.get("session", "migrated"),
             })
+            counter += 1
         else:
             # Already v3 format (mixed file), keep as-is
             upgraded.append(t)
-        counter += 1
 
     data["tasks"] = upgraded
     atomic_write_json(json_path, data)
@@ -599,16 +612,58 @@ def _find_task(walnut, task_id):
     """Find a task by ID across all tasks.json files.
 
     Returns (file_path, task_dict, data_dict) or exits with error.
+
+    Errors on an ambiguous id (more than one task shares it — a real
+    state on walnuts with mixed migration history, t140). Mutating
+    commands act on the returned object identity, so an ambiguous id
+    must never silently resolve to "first match": the caller would
+    mutate one task while the id-filter removal destroyed all of them.
     """
+    matches = []
     for tf in _all_task_files(walnut):
         data = _read_json(tf, "tasks", strict=False)
         if data is None:
             continue
         for task in data["tasks"]:
             if task.get("id") == task_id:
-                return tf, task, data
-    print("Error: task {} not found".format(task_id), file=sys.stderr)
-    sys.exit(1)
+                matches.append((tf, task, data))
+
+    if not matches:
+        print("Error: task {} not found".format(task_id), file=sys.stderr)
+        sys.exit(1)
+
+    if len(matches) > 1:
+        print(
+            "Error: {} tasks share id {} -- refusing to guess which one you mean:".format(
+                len(matches), task_id
+            ),
+            file=sys.stderr,
+        )
+        for tf, task, _data in matches:
+            print(
+                "  [{}] {}".format(
+                    os.path.relpath(tf, walnut), task.get("title", "(no title)")
+                ),
+                file=sys.stderr,
+            )
+        print(
+            "Duplicate ids come from pre-fix migrations. Re-key the duplicates "
+            "first (edit the tasks.json files directly), then retry.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    return matches[0]
+
+
+def _remove_task_by_identity(data, task):
+    """Remove exactly this task object from data["tasks"].
+
+    Never filter by id here: on a walnut with duplicate ids an id
+    filter deletes every task sharing the id while completed.json
+    records only one -- silent data loss (t140).
+    """
+    data["tasks"] = [t for t in data["tasks"] if t is not task]
 
 
 def _resolve_bundle_path(walnut, bundle):
@@ -967,8 +1022,8 @@ def cmd_done(args):
 
     tf, task, data = _find_task(walnut, args.id)
 
-    # Remove from source
-    data["tasks"] = [t for t in data["tasks"] if t.get("id") != args.id]
+    # Remove from source -- by object identity, never by id filter (t140)
+    _remove_task_by_identity(data, task)
     atomic_write_json(tf, data)
 
     # Add to completed.json
@@ -993,8 +1048,8 @@ def cmd_drop(args):
 
     tf, task, data = _find_task(walnut, args.id)
 
-    # Remove from source
-    data["tasks"] = [t for t in data["tasks"] if t.get("id") != args.id]
+    # Remove from source -- by object identity, never by id filter (t140)
+    _remove_task_by_identity(data, task)
     atomic_write_json(tf, data)
 
     # Add to completed.json

--- a/tests/release/test_tasks_id_collision.py
+++ b/tests/release/test_tasks_id_collision.py
@@ -1,0 +1,158 @@
+"""Regression tests for the tasks.py id-collision data loss (t140).
+
+Pre-fix v2->v3 migration assigned ids from a counter starting at 1
+with no awareness of ids already in the file, so mixed v2/v3 files got
+duplicate ids. ``cmd_done``/``cmd_drop`` then removed tasks with an id
+FILTER — deleting every task sharing the id in one call — while
+``_find_task`` resolved only the first match, so ``completed.json``
+recorded one task and the rest vanished with no record anywhere.
+Observed in production: 8 tasks silently deleted from a real walnut
+(recovered only via a pre-mutation snapshot), ~48 more live collisions
+found across two other walnuts.
+
+Pins: mutation on an ambiguous id refuses and exits 2 with both tasks
+intact; mutation on a unique id removes exactly that task; migration
+of a mixed file continues ids after the file's high-water mark.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TASKS = ROOT / "plugins" / "alive" / "scripts" / "tasks.py"
+
+
+def run_tasks(walnut: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TASKS), *args, "--walnut", str(walnut)],
+        text=True,
+        capture_output=True,
+    )
+
+
+def make_walnut(base: Path, tasks: list[dict]) -> Path:
+    walnut = base / "walnut"
+    kernel = walnut / "_kernel"
+    kernel.mkdir(parents=True)
+    (kernel / "key.md").write_text("# key\n", encoding="utf-8")
+    (kernel / "tasks.json").write_text(
+        json.dumps({"tasks": tasks}), encoding="utf-8"
+    )
+    return walnut
+
+
+def v3_task(tid: str, title: str) -> dict:
+    return {
+        "id": tid,
+        "title": title,
+        "status": "todo",
+        "priority": "todo",
+        "assignee": None,
+        "due": None,
+        "tags": [],
+        "created": "2026-09-01",
+        "session": "test",
+    }
+
+
+class AmbiguousIdRefusalTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.walnut = make_walnut(
+            Path(self._tmp.name),
+            [
+                v3_task("t001", "live task that must survive"),
+                v3_task("t002", "unique task"),
+                v3_task("t001", "stale duplicate from migration"),
+            ],
+        )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def read_tasks(self) -> list[dict]:
+        data = json.loads(
+            (self.walnut / "_kernel" / "tasks.json").read_text(encoding="utf-8")
+        )
+        return data["tasks"]
+
+    def test_done_on_duplicate_id_refuses_and_loses_nothing(self) -> None:
+        result = run_tasks(self.walnut, "done", "--id", "t001")
+
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("share id t001", result.stderr)
+        remaining = self.read_tasks()
+        self.assertEqual(len(remaining), 3, "no task may be removed on refusal")
+        completed = self.walnut / "_kernel" / "completed.json"
+        if completed.exists():
+            data = json.loads(completed.read_text(encoding="utf-8"))
+            self.assertEqual(data.get("completed", []), [])
+
+    def test_drop_on_duplicate_id_refuses_and_loses_nothing(self) -> None:
+        result = run_tasks(self.walnut, "drop", "--id", "t001")
+
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertEqual(len(self.read_tasks()), 3)
+
+    def test_edit_on_duplicate_id_refuses(self) -> None:
+        result = run_tasks(
+            self.walnut, "edit", "--id", "t001", "--priority", "urgent"
+        )
+
+        self.assertEqual(result.returncode, 2, result.stderr)
+        for task in self.read_tasks():
+            self.assertNotEqual(
+                task.get("priority"), "urgent", "no task may be edited on refusal"
+            )
+
+    def test_done_on_unique_id_removes_exactly_one(self) -> None:
+        result = run_tasks(self.walnut, "done", "--id", "t002")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        remaining = self.read_tasks()
+        self.assertEqual(len(remaining), 2)
+        self.assertTrue(all(t["id"] == "t001" for t in remaining))
+        completed = json.loads(
+            (self.walnut / "_kernel" / "completed.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(len(completed["completed"]), 1)
+        self.assertEqual(completed["completed"][0]["title"], "unique task")
+
+
+class MigrationRekeyTest(unittest.TestCase):
+    def test_mixed_file_migration_continues_after_high_water_mark(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            walnut = make_walnut(
+                Path(tmp),
+                [
+                    v3_task("t001", "existing v3 one"),
+                    v3_task("t007", "existing v3 with high id"),
+                    {"text": "legacy v2 task A", "status": "todo", "priority": "normal"},
+                    {"text": "legacy v2 task B", "status": "todo", "priority": "urgent"},
+                ],
+            )
+
+            # Any list invocation triggers the in-place upgrade.
+            result = run_tasks(walnut, "list")
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            data = json.loads(
+                (walnut / "_kernel" / "tasks.json").read_text(encoding="utf-8")
+            )
+            ids = [t["id"] for t in data["tasks"]]
+            self.assertEqual(
+                len(ids), len(set(ids)), f"migration produced duplicate ids: {ids}"
+            )
+            self.assertIn("t008", ids)
+            self.assertIn("t009", ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fixes #96

- _find_task collects all matches and refuses ambiguous ids (exit 2, lists each match with file + title) instead of silently resolving to the first
- done/drop remove by object identity, never by id filter - the filter was deleting every task sharing the id while completed.json recorded one
- edit inherits the same refusal (was mutating whichever twin came first)
- the v2->v3 upgrade now continues ids after the file's high-water mark instead of restarting at 1, so mixed files stop producing duplicates in the first place

5 regression tests - 4 fail against the pre-fix code, all pass here. full suite otherwise green.

note: this makes mutation SAFE on already-corrupted walnuts (it refuses), but doesn't auto-repair existing duplicates - a de-dup sweep belongs in system-cleanup, tracked separately in #89's upgrade additions.